### PR TITLE
WIP Selection hierarchique bug avec re-selection #7751

### DIFF
--- a/projects/natural/src/lib/modules/common/directives/reactive-asterisk.directive.ts
+++ b/projects/natural/src/lib/modules/common/directives/reactive-asterisk.directive.ts
@@ -12,7 +12,7 @@ import {MatSelect} from '@angular/material/select';
     selector: 'mat-form-field:has(input:not([required])), mat-form-field:has(mat-select:not([required]))',
 })
 export class ReactiveAsteriskDirective implements AfterContentChecked {
-    constructor(@Optional() private matFormField: MatFormField) {}
+    constructor(@Optional() private matFormField: MatFormField | null) {}
 
     public ngAfterContentChecked(): void {
         const ctrl = this.matFormField?._control;

--- a/projects/natural/src/lib/modules/select/abstract-select.component.ts
+++ b/projects/natural/src/lib/modules/select/abstract-select.component.ts
@@ -103,7 +103,7 @@ export abstract class AbstractSelect<V>
      * - NaturalSelectHierarchicComponent: `string | null`.
      * - NaturalSelectEnumComponent: `V | null`.
      */
-    public internalCtrl: FormControl = new FormControl();
+    public readonly internalCtrl: FormControl = new FormControl();
 
     /**
      * Interface with ControlValueAccessor
@@ -130,15 +130,13 @@ export abstract class AbstractSelect<V>
     }
 
     public ngDoCheck(): void {
-        if (this.internalCtrl && this.ngControl) {
+        if (this.ngControl) {
             this.applyRequired();
         }
     }
 
     public writeValue(value: V | null): void {
-        if (this.internalCtrl) {
-            this.internalCtrl.setValue(value);
-        }
+        this.internalCtrl.setValue(value);
     }
 
     public ngOnInit(): void {
@@ -152,9 +150,7 @@ export abstract class AbstractSelect<V>
      * Whether the value can be changed
      */
     @Input() set disabled(disabled: boolean) {
-        if (this.internalCtrl) {
-            disabled ? this.internalCtrl.disable() : this.internalCtrl.enable();
-        }
+        disabled ? this.internalCtrl.disable() : this.internalCtrl.enable();
     }
 
     public registerOnChange(fn: (item: V | null) => void): void {

--- a/projects/natural/src/lib/modules/select/abstract-select.component.ts
+++ b/projects/natural/src/lib/modules/select/abstract-select.component.ts
@@ -119,7 +119,7 @@ export abstract class AbstractSelect<V>
 
     public matcher: ExternalFormControlMatcher<V>;
 
-    constructor(@Optional() @Self() public readonly ngControl: NgControl) {
+    constructor(@Optional() @Self() public readonly ngControl: NgControl | null) {
         super();
 
         if (this.ngControl) {

--- a/projects/natural/src/lib/modules/select/abstract-select.component.ts
+++ b/projects/natural/src/lib/modules/select/abstract-select.component.ts
@@ -98,8 +98,10 @@ export abstract class AbstractSelect<V>
      *
      * It is **not** necessarily `V | null`.
      *
-     * For NaturalSelectComponent and NaturalSelectHierarchicComponent, it is `string | null`.
-     * For NaturalSelectEnumComponent, it is `V | null`.
+     * - NaturalSelectComponent: `string | V | null`. We allow `string`
+     *   only when `optionRequired` is false, so most of the time it is `V | null`.
+     * - NaturalSelectHierarchicComponent: `string | null`.
+     * - NaturalSelectEnumComponent: `V | null`.
      */
     public internalCtrl: FormControl = new FormControl();
 
@@ -135,7 +137,7 @@ export abstract class AbstractSelect<V>
 
     public writeValue(value: V | null): void {
         if (this.internalCtrl) {
-            this.internalCtrl.setValue(this.getDisplayFn()(value));
+            this.internalCtrl.setValue(value);
         }
     }
 

--- a/projects/natural/src/lib/modules/select/abstract-select.component.ts
+++ b/projects/natural/src/lib/modules/select/abstract-select.component.ts
@@ -94,7 +94,12 @@ export abstract class AbstractSelect<V>
     @Output() public readonly blur = new EventEmitter<void>();
 
     /**
+     * Contains internal representation for current selection.
      *
+     * It is **not** necessarily `V | null`.
+     *
+     * For NaturalSelectComponent and NaturalSelectHierarchicComponent, it is `string | null`.
+     * For NaturalSelectEnumComponent, it is `V | null`.
      */
     public formCtrl: FormControl = new FormControl();
 

--- a/projects/natural/src/lib/modules/select/select-enum/select-enum.component.html
+++ b/projects/natural/src/lib/modules/select/select-enum/select-enum.component.html
@@ -2,7 +2,7 @@
     <mat-label>{{ placeholder }}</mat-label>
     <mat-select
         (selectionChange)="propagateValue($event.value)"
-        [formControl]="formCtrl"
+        [formControl]="internalCtrl"
         (blur)="touch(); blur.emit()"
         [errorStateMatcher]="matcher"
     >

--- a/projects/natural/src/lib/modules/select/select-enum/select-enum.component.ts
+++ b/projects/natural/src/lib/modules/select/select-enum/select-enum.component.ts
@@ -28,7 +28,7 @@ export class NaturalSelectEnumComponent extends AbstractSelect<IEnum['value']> i
 
     constructor(
         private readonly enumService: NaturalEnumService,
-        @Optional() @Self() public readonly ngControl: NgControl,
+        @Optional() @Self() public readonly ngControl: NgControl | null,
     ) {
         super(ngControl);
     }

--- a/projects/natural/src/lib/modules/select/select-enum/select-enum.component.ts
+++ b/projects/natural/src/lib/modules/select/select-enum/select-enum.component.ts
@@ -45,6 +45,6 @@ export class NaturalSelectEnumComponent extends AbstractSelect<IEnum['value']> i
     }
 
     public getDisplayFn(): (item: IEnum['value'] | null) => string {
-        return () => '';
+        throw new Error('This should never be called');
     }
 }

--- a/projects/natural/src/lib/modules/select/select-enum/select-enum.component.ts
+++ b/projects/natural/src/lib/modules/select/select-enum/select-enum.component.ts
@@ -39,8 +39,8 @@ export class NaturalSelectEnumComponent extends AbstractSelect<IEnum['value']> i
     }
 
     public writeValue(value: IEnum['value'] | null): void {
-        if (this.formCtrl) {
-            this.formCtrl.setValue(value);
+        if (this.internalCtrl) {
+            this.internalCtrl.setValue(value);
         }
     }
 

--- a/projects/natural/src/lib/modules/select/select-enum/select-enum.component.ts
+++ b/projects/natural/src/lib/modules/select/select-enum/select-enum.component.ts
@@ -38,12 +38,6 @@ export class NaturalSelectEnumComponent extends AbstractSelect<IEnum['value']> i
         this.items = this.enumService.get(this.enumName);
     }
 
-    public writeValue(value: IEnum['value'] | null): void {
-        if (this.internalCtrl) {
-            this.internalCtrl.setValue(value);
-        }
-    }
-
     public getDisplayFn(): (item: IEnum['value'] | null) => string {
         throw new Error('This should never be called');
     }

--- a/projects/natural/src/lib/modules/select/select-hierarchic/select-hierarchic.component.html
+++ b/projects/natural/src/lib/modules/select/select-hierarchic/select-hierarchic.component.html
@@ -6,7 +6,7 @@
         (blur)="blur.emit()"
         (focus)="openDialog()"
         (keydown.esc)="clear()"
-        [formControl]="formCtrl"
+        [formControl]="internalCtrl"
         [errorStateMatcher]="matcher"
         aria-label="Recherche et sélection"
         i18n-aria-label="natural|"
@@ -20,7 +20,7 @@
     <div class="suffix-buttons" matSuffix>
         <button
             (click)="clear(); $event.stopPropagation()"
-            *ngIf="formCtrl.value && formCtrl.enabled && !clearLabel"
+            *ngIf="internalCtrl.value && internalCtrl.enabled && !clearLabel"
             mat-icon-button
             i18n-matTooltip="natural|"
             matTooltip="Désélectionner"
@@ -28,7 +28,7 @@
             <natural-icon name="close"></natural-icon>
         </button>
         <button
-            *ngIf="formCtrl.value && navigateTo"
+            *ngIf="internalCtrl.value && navigateTo"
             [routerLink]="navigateTo"
             mat-button
             mat-icon-button

--- a/projects/natural/src/lib/modules/select/select-hierarchic/select-hierarchic.component.spec.ts
+++ b/projects/natural/src/lib/modules/select/select-hierarchic/select-hierarchic.component.spec.ts
@@ -1,10 +1,14 @@
 // tslint:disable:directive-class-suffix
-import {waitForAsync, TestBed} from '@angular/core/testing';
+import {fakeAsync, TestBed, waitForAsync} from '@angular/core/testing';
 import {
+    HierarchicDialogResult,
+    NaturalHierarchicSelectorDialogComponent,
+    NaturalHierarchicSelectorDialogService,
     NaturalHierarchicSelectorModule,
     NaturalIconModule,
     NaturalSelectHierarchicComponent,
     NaturalSelectModule,
+    OrganizedModelSelection,
 } from '@ecodev/natural';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Component} from '@angular/core';
@@ -17,6 +21,9 @@ import {
     testSelectAndSelectHierarchicCommonBehavior,
 } from '../testing/utils';
 import {By} from '@angular/platform-browser';
+import {of} from 'rxjs';
+import {MatDialogRef} from '@angular/material/dialog';
+import {AnyService} from '../../../testing/any.service';
 
 @Component({
     template: `
@@ -47,7 +54,7 @@ class TestHostWithHierarchicAndNgModelComponent extends AbstractTestHostWithNgMo
 class TestHostWithHierarchicAndFormControlComponent extends AbstractTestHostWithFormControlComponent {}
 
 describe('NaturalSelectHierarchicComponent', () => {
-    const data: TestFixture = {
+    const data: TestFixture<NaturalSelectHierarchicComponent> = {
         hostComponent: null as any,
         selectComponent: null as any,
         fixture: null as any,
@@ -84,6 +91,7 @@ describe('NaturalSelectHierarchicComponent', () => {
         });
 
         testSelectAndSelectHierarchicCommonBehavior(data);
+        testSelectHierarchicBehavior(data);
     });
 
     describe('with formControl', () => {
@@ -97,5 +105,66 @@ describe('NaturalSelectHierarchicComponent', () => {
         });
 
         testSelectAndSelectHierarchicCommonBehavior(data);
+        testSelectHierarchicBehavior(data);
     });
 });
+
+function mockDialogRef(
+    selection: OrganizedModelSelection | undefined,
+): MatDialogRef<NaturalHierarchicSelectorDialogComponent, HierarchicDialogResult> {
+    const fakeSelection: HierarchicDialogResult = {
+        hierarchicSelection: selection,
+        searchSelections: [],
+    };
+
+    return ({
+        afterClosed: () => of(fakeSelection),
+    } as unknown) as MatDialogRef<NaturalHierarchicSelectorDialogComponent, HierarchicDialogResult>;
+}
+
+function testSelectHierarchicBehavior(data: TestFixture<NaturalSelectHierarchicComponent>): void {
+    it(`should be able to open dialog, select item, validate, re-open dialog, **see** previous selection, validate`, fakeAsync(() => {
+        const hierarchicSelectorDialogService = TestBed.inject(NaturalHierarchicSelectorDialogService);
+        const anyService = TestBed.inject(AnyService);
+        const item = anyService.getItem();
+
+        const spy = spyOn(hierarchicSelectorDialogService, 'open');
+
+        // Mock first selection of an item coming from service
+        spy.withArgs(
+            {
+                hierarchicConfig: data.selectComponent.config,
+                hierarchicSelection: {},
+                hierarchicFilters: undefined,
+                multiple: false,
+            },
+            {restoreFocus: false},
+        ).and.callFake(() => mockDialogRef({any: [item]}));
+
+        // Mock second selection of the item that is already selected, so it simulates
+        // a human who opens the dialog and closes it immediately with "Valider" button
+        spy.withArgs(
+            {
+                hierarchicConfig: data.selectComponent.config,
+                hierarchicSelection: {any: [item]},
+                hierarchicFilters: undefined,
+                multiple: false,
+            },
+            {restoreFocus: false},
+        ).and.callFake(hierarchicConfig => mockDialogRef(hierarchicConfig.hierarchicSelection));
+
+        // Trigger the selection of item in mocked dialog
+        data.selectComponent.openDialog();
+
+        const value = data.hostComponent.getValue();
+        expect(value).toEqual(item);
+
+        // Trigger the re-selection in mocked dialog
+        data.selectComponent.openDialog();
+
+        const valueAfterReSelection = data.hostComponent.getValue();
+        expect(valueAfterReSelection).toEqual(item);
+
+        expect(spy).toHaveBeenCalledTimes(2);
+    }));
+}

--- a/projects/natural/src/lib/modules/select/select-hierarchic/select-hierarchic.component.ts
+++ b/projects/natural/src/lib/modules/select/select-hierarchic/select-hierarchic.component.ts
@@ -56,6 +56,11 @@ export class NaturalSelectHierarchicComponent
     @Input() public filters?: HierarchicFiltersConfiguration;
 
     /**
+     * The selected value as an object. The inner value is formCtrl.value that is a string.
+     */
+    private value: Literal | null = null;
+
+    /**
      * On Firefox, the combination of <input (focus)> event and dialog opening cause some strange bug where focus event is called multiple
      * times This prevents it.
      */
@@ -79,6 +84,11 @@ export class NaturalSelectHierarchicComponent
         return defaultDisplayFn;
     }
 
+    public writeValue(value: Literal | null): void {
+        this.value = value;
+        super.writeValue(value);
+    }
+
     public openDialog(): void {
         if (this.formCtrl.disabled) {
             return;
@@ -98,7 +108,7 @@ export class NaturalSelectHierarchicComponent
         const selected: OrganizedModelSelection = {};
 
         if (this.formCtrl.value) {
-            selected[selectAtKey] = [this.formCtrl.value];
+            selected[selectAtKey] = [this.value];
         }
 
         const hierarchicConfig: HierarchicDialogConfig = {

--- a/projects/natural/src/lib/modules/select/select-hierarchic/select-hierarchic.component.ts
+++ b/projects/natural/src/lib/modules/select/select-hierarchic/select-hierarchic.component.ts
@@ -89,9 +89,7 @@ export class NaturalSelectHierarchicComponent
      */
     public writeValue(value: Literal | null): void {
         this.value = value;
-        if (this.internalCtrl) {
-            this.internalCtrl.setValue(this.getDisplayFn()(value));
-        }
+        this.internalCtrl.setValue(this.getDisplayFn()(value));
     }
 
     public openDialog(): void {

--- a/projects/natural/src/lib/modules/select/select-hierarchic/select-hierarchic.component.ts
+++ b/projects/natural/src/lib/modules/select/select-hierarchic/select-hierarchic.component.ts
@@ -68,7 +68,7 @@ export class NaturalSelectHierarchicComponent
 
     constructor(
         private readonly hierarchicSelectorDialogService: NaturalHierarchicSelectorDialogService,
-        @Optional() @Self() ngControl: NgControl,
+        @Optional() @Self() ngControl: NgControl | null,
     ) {
         super(ngControl);
     }

--- a/projects/natural/src/lib/modules/select/select-hierarchic/select-hierarchic.component.ts
+++ b/projects/natural/src/lib/modules/select/select-hierarchic/select-hierarchic.component.ts
@@ -56,7 +56,7 @@ export class NaturalSelectHierarchicComponent
     @Input() public filters?: HierarchicFiltersConfiguration;
 
     /**
-     * The selected value as an object. The inner value is formCtrl.value that is a string.
+     * The selected value as an object. The internal value is `internalCtrl.value`, and that is a string.
      */
     private value: Literal | null = null;
 
@@ -90,7 +90,7 @@ export class NaturalSelectHierarchicComponent
     }
 
     public openDialog(): void {
-        if (this.formCtrl.disabled) {
+        if (this.internalCtrl.disabled) {
             return;
         }
 
@@ -107,7 +107,7 @@ export class NaturalSelectHierarchicComponent
         const selectAtKey = this.getSelectKey();
         const selected: OrganizedModelSelection = {};
 
-        if (this.formCtrl.value) {
+        if (this.internalCtrl.value) {
             selected[selectAtKey] = [this.value];
         }
 
@@ -138,7 +138,7 @@ export class NaturalSelectHierarchicComponent
     }
 
     public showSelectButton(): boolean {
-        return !!(this.formCtrl?.enabled && this.selectLabel && this.config);
+        return !!(this.internalCtrl?.enabled && this.selectLabel && this.config);
     }
 
     private getSelectKey(): string {

--- a/projects/natural/src/lib/modules/select/select-hierarchic/select-hierarchic.component.ts
+++ b/projects/natural/src/lib/modules/select/select-hierarchic/select-hierarchic.component.ts
@@ -84,9 +84,14 @@ export class NaturalSelectHierarchicComponent
         return defaultDisplayFn;
     }
 
+    /**
+     * Override parent because our internalCtrl store the textual representation as string instead of raw Literal
+     */
     public writeValue(value: Literal | null): void {
         this.value = value;
-        super.writeValue(value);
+        if (this.internalCtrl) {
+            this.internalCtrl.setValue(this.getDisplayFn()(value));
+        }
     }
 
     public openDialog(): void {

--- a/projects/natural/src/lib/modules/select/select/select.component.html
+++ b/projects/natural/src/lib/modules/select/select/select.component.html
@@ -26,11 +26,11 @@
 
     <input
         (blur)="touch(); blur.emit()"
-        (change)="onInnerFormChange()"
+        (change)="onInternalFormChange()"
         (click)="autoTrigger.openPanel()"
         (focus)="startSearch()"
         (keydown.esc)="clear()"
-        [formControl]="formCtrl"
+        [formControl]="internalCtrl"
         [matAutocomplete]="ac"
         aria-label="Recherche et sélection"
         i18n-aria-label="natural|"
@@ -52,7 +52,7 @@
     <div class="suffix-buttons" matSuffix>
         <button
             (click)="clear(); $event.stopPropagation()"
-            *ngIf="formCtrl.value && formCtrl.enabled && !clearLabel"
+            *ngIf="internalCtrl.value && internalCtrl.enabled && !clearLabel"
             mat-icon-button
             i18n-matTooltip="natural|"
             matTooltip="Désélectionner"
@@ -60,7 +60,7 @@
             <natural-icon name="close"></natural-icon>
         </button>
         <button
-            *ngIf="formCtrl.value && navigateTo"
+            *ngIf="internalCtrl.value && navigateTo"
             [routerLink]="navigateTo"
             mat-button
             mat-icon-button

--- a/projects/natural/src/lib/modules/select/select/select.component.ts
+++ b/projects/natural/src/lib/modules/select/select/select.component.ts
@@ -93,11 +93,6 @@ export class NaturalSelectComponent<
     public loading = false;
 
     /**
-     * Storage for auto complete
-     */
-    public ac: any; // TODO actually not sure if this is needed at all ?
-
-    /**
      * Number of items not shown in result list
      * Shows a message after list if positive
      */

--- a/projects/natural/src/lib/modules/select/select/select.component.ts
+++ b/projects/natural/src/lib/modules/select/select/select.component.ts
@@ -117,21 +117,21 @@ export class NaturalSelectComponent<
      * Whether the value can be changed
      */
     @Input() set disabled(disabled: boolean) {
-        if (this.formCtrl) {
-            disabled ? this.formCtrl.disable() : this.formCtrl.enable();
+        if (this.internalCtrl) {
+            disabled ? this.internalCtrl.disable() : this.internalCtrl.enable();
         }
     }
 
     public ngAfterViewInit(): void {
-        this.formCtrl.valueChanges
+        this.internalCtrl.valueChanges
             .pipe(takeUntil(this.ngUnsubscribe), distinctUntilChanged(), debounceTime(300))
             .subscribe(val => this.search(val));
     }
 
-    public onInnerFormChange(): void {
+    public onInternalFormChange(): void {
         // If we allow free string typing, then we propagate it as it is being typed
         if (!this.optionRequired) {
-            this.propagateValue(this.formCtrl.value);
+            this.propagateValue(this.internalCtrl.value);
         }
     }
 
@@ -229,7 +229,7 @@ export class NaturalSelectComponent<
     }
 
     public showClearButton(): boolean {
-        return this.formCtrl?.enabled && this.clearLabel && this.formCtrl.value;
+        return this.internalCtrl?.enabled && this.clearLabel && this.internalCtrl.value;
     }
 
     private getSearchFilter(term: string | null): QueryVariables {

--- a/projects/natural/src/lib/modules/select/select/select.component.ts
+++ b/projects/natural/src/lib/modules/select/select/select.component.ts
@@ -117,9 +117,7 @@ export class NaturalSelectComponent<
      * Whether the value can be changed
      */
     @Input() set disabled(disabled: boolean) {
-        if (this.internalCtrl) {
-            disabled ? this.internalCtrl.disable() : this.internalCtrl.enable();
-        }
+        disabled ? this.internalCtrl.disable() : this.internalCtrl.enable();
     }
 
     public ngAfterViewInit(): void {

--- a/src/app/select/select.component.ts
+++ b/src/app/select/select.component.ts
@@ -2,7 +2,6 @@ import {Component} from '@angular/core';
 import {AnyService} from '../../../projects/natural/src/lib/testing/any.service';
 import {ErrorService} from '../../../projects/natural/src/lib/testing/error.service';
 import {AbstractSelect} from '../AbstractSelect';
-import {NaturalAbstractModelService, PaginatedData, QueryVariables} from '@ecodev/natural';
 
 @Component({
     selector: 'app-select',


### PR DESCRIPTION
Le sélecteur hiérarchique a un problème qui se manifeste en deux points. Après sélection normale d'un élément, si on rouvre le dialog, l'élément déjà sélectionné n'est pas affiché correctement. Deuxièmement si on ferme en validant, mais sans rien toucher d'autre, la sélection est modifiée pour une valeur qui est invalide. Alors qu'en fait la sélection ne devrait pas être modifiée du tout.

Le début du problème vient de `AbstractSelect.writeValue` qui convertit l'objet en en string via `getDisplay`. Le dilemme, c'est qu'on a à la fois besoin d'un string pour afficher dans le matInput (ce qu'on fait), et à la fois besoin de conserver l'objet pour le remontrer à la réouverture du dialog (ce qu'on ne fait pas).

Le vrai fond du problème c'est que AbstractSelect.formCtrl contient parfois un string, et parfois un objet, suivant d'où provient la valeur.

IMHO on devrait formaliser que AbstractSelect.formCtrl contient toujours `V | null`, donc pour un hiérarchique cela veut dire que c'est un objet et jamais un string. Puis juste pour le hiérarchique introduire un deuxième control du genre `internalStringCtrl` qui contient `string | null` et qui est utilisé uniquement à des fins d'affichage pour matInput.

@sambaptista, puisque cela touche à une partie super-sensible, que nous avons déjà refactoré plusieurs fois, qu'est-ce que t'en penses ? Quelle est serait l'approche la plus raisonnable ?

Tu peux sans autre pousser des commits sur la branche dédiée jusqu'à qu'on obtienne un résultat satisfaisant.

A première vue cela semble anodin, un simple souci d'affichage, mais le bug mène à faire des requêtes GraphQL totalement invalide (vu dans nos logs en production), et c'est donc important de corriger cela plutôt vite.


![issue-7751 mp4](https://user-images.githubusercontent.com/72603/101592471-a6baca80-3a31-11eb-822e-4168a33a0edf.gif)
