### PR TITLE
Allow 404 fallback mechanism with panels  #7909

### DIFF
--- a/projects/natural/src/lib/modules/common/services/seo.service.spec.ts
+++ b/projects/natural/src/lib/modules/common/services/seo.service.spec.ts
@@ -7,11 +7,6 @@ import {Router, Routes} from '@angular/router';
 import {Meta, Title} from '@angular/platform-browser';
 
 @Component({
-    template: '<router-outlet></router-outlet>',
-})
-class TestRootComponent {}
-
-@Component({
     template: ` <div>Test component</div>`,
 })
 class TestSimpleComponent {}

--- a/projects/natural/src/lib/modules/panels/fallback-if-no-opened-panels.urlmatcher.ts
+++ b/projects/natural/src/lib/modules/panels/fallback-if-no-opened-panels.urlmatcher.ts
@@ -1,0 +1,18 @@
+import {Route, UrlMatcher, UrlMatchResult, UrlSegment, UrlSegmentGroup} from '@angular/router';
+import {NaturalPanelsService} from './panels.service';
+
+/**
+ * Url fallback matcher to be used instead of `path: '**'` when Panel system
+ * is used in the project.
+ */
+export const fallbackIfNoOpenedPanels: UrlMatcher = (
+    segments: UrlSegment[],
+    group: UrlSegmentGroup,
+    route: Route,
+): UrlMatchResult | null => {
+    if (!NaturalPanelsService.opened) {
+        return {consumed: segments};
+    }
+
+    return null;
+};

--- a/projects/natural/src/lib/modules/panels/panels.module.ts
+++ b/projects/natural/src/lib/modules/panels/panels.module.ts
@@ -5,10 +5,12 @@ import {RouterModule} from '@angular/router';
 import {NaturalPanelsComponent} from './panels.component';
 import {NaturalPanelsHooksConfig, PanelsHooksConfig} from './types';
 
+const declarations = [NaturalPanelsComponent];
+
 @NgModule({
-    declarations: [NaturalPanelsComponent],
+    declarations: declarations,
     imports: [CommonModule, RouterModule, MatDialogModule],
-    exports: [NaturalPanelsComponent],
+    exports: declarations,
 })
 export class NaturalPanelsModule {
     public static forRoot(hooks?: NaturalPanelsHooksConfig): ModuleWithProviders<NaturalPanelsModule> {

--- a/projects/natural/src/lib/modules/panels/panels.service.ts
+++ b/projects/natural/src/lib/modules/panels/panels.service.ts
@@ -1,11 +1,11 @@
 import {ComponentType} from '@angular/cdk/portal';
 import {Inject, Injectable, Injector} from '@angular/core';
-import {MediaChange, MediaObserver} from '@angular/flex-layout';
+import {MediaObserver} from '@angular/flex-layout';
 import {MatDialog, MatDialogConfig} from '@angular/material/dialog';
 import {ActivatedRoute, DefaultUrlSerializer, NavigationError, Router, UrlSegment} from '@angular/router';
 import {differenceWith, flatten, isEqual} from 'lodash-es';
 import {forkJoin, Observable, of, Subject, Subscription} from 'rxjs';
-import {filter, map} from 'rxjs/operators';
+import {map} from 'rxjs/operators';
 import {NaturalAbstractPanel} from './abstract-panel';
 import {getStackConfig} from './panels.urlmatcher';
 import {

--- a/projects/natural/src/lib/modules/panels/panels.service.ts
+++ b/projects/natural/src/lib/modules/panels/panels.service.ts
@@ -33,6 +33,10 @@ function compareConfigs(a: NaturalPanelConfig, b: NaturalPanelConfig): boolean {
     providedIn: 'root',
 })
 export class NaturalPanelsService {
+    /**
+     * Because of this static property Panels are **not** compatible with SSR.
+     * And we cannot make it non-static, because `UrlMatcher` cannot be injected.
+     */
     private static _opened = false;
     public static get opened(): boolean {
         return this._opened;

--- a/projects/natural/src/lib/modules/panels/panels.spec.ts
+++ b/projects/natural/src/lib/modules/panels/panels.spec.ts
@@ -25,45 +25,25 @@ class TestRootComponent {
 }
 
 @Component({
-    template: `
-        <div class="page-without-panels">
-            <h1>Page without panels at all</h1>
-        </div>
-    `,
+    template: `<h1>Page without panels at all</h1>`,
 })
 class TestNoPanelComponent {}
 
 @Component({
     template: `
-        <div class="page-with-panels">
-            <h1>Page with panels</h1>
-            <a class="link-panel-a-2" [routerLink]="['panel-a', '2']">Panel A 2 (dynamic)</a>
-            <a class="link-panel-a-3" routerLink="panel-a/3">Panel A 3 (static)</a>
-            <a class="link-panel-b" routerLink="panel-b">Panel B (static)</a>
-            <router-outlet></router-outlet>
-        </div>
+        <h1>Page with panels</h1>
+        <router-outlet></router-outlet>
     `,
 })
 class TestWithPanelComponent {}
 
 @Component({
-    template: `
-        <div class="panel-a-content">
-            <h1>Panel A content</h1>
-            <a class="link-panel-a-2" [routerLink]="['panel-a', '2']">Panel A 2 (dynamic)</a>
-            <a class="link-panel-a-3" routerLink="panel-a/3">Panel A 3 (static)</a>
-            <a class="link-panel-b" routerLink="panel-b">Panel B (static)</a>
-        </div>
-    `,
+    template: `<h1>Panel A content</h1>`,
 })
 class TestPanelAComponent extends NaturalAbstractPanel {}
 
 @Component({
-    template: `
-        <div class="panel-b-content">
-            <h1>Panel B content</h1>
-        </div>
-    `,
+    template: `<h1>Panel B content</h1>`,
 })
 class TestPanelBComponent extends NaturalAbstractPanel {}
 

--- a/projects/natural/src/lib/modules/panels/panels.spec.ts
+++ b/projects/natural/src/lib/modules/panels/panels.spec.ts
@@ -1,0 +1,282 @@
+import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {RouterTestingModule} from '@angular/router/testing';
+import {
+    NaturalAbstractPanel,
+    NaturalPanelConfig,
+    NaturalPanelData,
+    NaturalPanelResolve,
+    NaturalPanelsComponent,
+    NaturalPanelsModule,
+    NaturalPanelsRouterRule,
+    naturalPanelsUrlMatcher,
+} from '@ecodev/natural';
+import {Component, Injectable, NgZone, ViewChild} from '@angular/core';
+import {Router, RouterOutlet, Routes, UrlSegment} from '@angular/router';
+import {Observable, of} from 'rxjs';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {MatDialog} from '@angular/material/dialog';
+
+@Component({
+    template: '<router-outlet></router-outlet>',
+})
+class TestRootComponent {
+    @ViewChild(RouterOutlet) public routerOutlet!: RouterOutlet;
+}
+
+@Component({
+    template: `
+        <div class="page-without-panels">
+            <h1>Page without panels at all</h1>
+        </div>
+    `,
+})
+class TestNoPanelComponent {}
+
+@Component({
+    template: `
+        <div class="page-with-panels">
+            <h1>Page with panels</h1>
+            <a class="link-panel-a-2" [routerLink]="['panel-a', '2']">Panel A 2 (dynamic)</a>
+            <a class="link-panel-a-3" routerLink="panel-a/3">Panel A 3 (static)</a>
+            <a class="link-panel-b" routerLink="panel-b">Panel B (static)</a>
+            <router-outlet></router-outlet>
+        </div>
+    `,
+})
+class TestWithPanelComponent {}
+
+@Component({
+    template: `
+        <div class="panel-a-content">
+            <h1>Panel A content</h1>
+            <a class="link-panel-a-2" [routerLink]="['panel-a', '2']">Panel A 2 (dynamic)</a>
+            <a class="link-panel-a-3" routerLink="panel-a/3">Panel A 3 (static)</a>
+            <a class="link-panel-b" routerLink="panel-b">Panel B (static)</a>
+        </div>
+    `,
+})
+class TestPanelAComponent extends NaturalAbstractPanel {}
+
+@Component({
+    template: `
+        <div class="panel-b-content">
+            <h1>Panel B content</h1>
+        </div>
+    `,
+})
+class TestPanelBComponent extends NaturalAbstractPanel {}
+
+@Injectable({
+    providedIn: 'root',
+})
+class MyResolver implements NaturalPanelResolve<string> {
+    public resolve(route: NaturalPanelConfig): Observable<string> {
+        return of('my resolved data');
+    }
+}
+
+const panelsRoutes: NaturalPanelsRouterRule[] = [
+    {
+        path: 'panel-a/:param',
+        component: TestPanelAComponent,
+        resolve: {foo: MyResolver},
+    },
+    {
+        path: 'panel-b/:param',
+        component: TestPanelBComponent,
+    },
+];
+
+const routesWithoutFallback: Routes = [
+    {
+        path: 'no-panels',
+        component: TestNoPanelComponent,
+    },
+    {
+        path: 'with-panels',
+        component: TestWithPanelComponent,
+        children: [
+            {
+                matcher: naturalPanelsUrlMatcher,
+                component: NaturalPanelsComponent,
+                data: {panelsRoutes: panelsRoutes},
+            },
+        ],
+    },
+];
+
+function injectPanelCount(panelData: NaturalPanelData, pc: string): void {
+    panelData.config.params.pc = pc;
+    const lastSegment = panelData.config.route.segments[panelData.config.route.segments.length - 1];
+    lastSegment.parameters.pc = pc;
+}
+
+describe('Panels', () => {
+    let rootFixture: ComponentFixture<TestRootComponent>;
+    let rootComponent: TestRootComponent;
+    let router: Router;
+    let ngZone: NgZone;
+    let dialog: MatDialog;
+    let myResolver: MyResolver;
+    let panelA2: NaturalPanelData;
+    let panelA3: NaturalPanelData;
+    let panelB1: NaturalPanelData;
+
+    async function configure(routes: Routes): Promise<void> {
+        await TestBed.configureTestingModule({
+            imports: [NoopAnimationsModule, RouterTestingModule.withRoutes(routes), NaturalPanelsModule.forRoot()],
+            declarations: [
+                TestRootComponent,
+                TestNoPanelComponent,
+                TestWithPanelComponent,
+                TestPanelAComponent,
+                TestPanelBComponent,
+            ],
+        }).compileComponents();
+
+        rootFixture = TestBed.createComponent(TestRootComponent);
+        console.log('rootFixture', rootFixture);
+        rootComponent = rootFixture.componentInstance;
+        router = TestBed.inject(Router);
+        ngZone = TestBed.inject(NgZone);
+        dialog = TestBed.inject(MatDialog);
+        myResolver = TestBed.inject(MyResolver);
+
+        rootFixture.detectChanges();
+
+        router.events.subscribe(e => {
+            console.group(`Router Event: ${e.constructor.name}`);
+            console.log(e.toString());
+            console.log(e);
+            console.groupEnd();
+        });
+
+        panelA2 = {
+            config: {
+                component: TestPanelAComponent,
+                resolve: {
+                    foo: myResolver,
+                },
+                params: {
+                    param: '2',
+                },
+                rule: {
+                    path: 'panel-a/:param',
+                    component: TestPanelAComponent,
+                    resolve: {
+                        foo: MyResolver,
+                    },
+                },
+                route: {
+                    segments: [new UrlSegment('panel-a', {}), new UrlSegment('2', {})],
+                    path: 'panel-a/2',
+                },
+            },
+            data: {
+                foo: 'my resolved data',
+            },
+            linkableObjects: [],
+        };
+
+        panelA3 = {
+            config: {
+                component: TestPanelAComponent,
+                resolve: {
+                    foo: myResolver,
+                },
+                params: {
+                    param: '3',
+                },
+                rule: {
+                    path: 'panel-a/:param',
+                    component: TestPanelAComponent,
+                    resolve: {
+                        foo: MyResolver,
+                    },
+                },
+                route: {
+                    segments: [new UrlSegment('panel-a', {}), new UrlSegment('3', {})],
+                    path: 'panel-a/3',
+                },
+            },
+            data: {
+                foo: 'my resolved data',
+            },
+            linkableObjects: [],
+        };
+
+        panelB1 = {
+            config: {
+                component: TestPanelBComponent,
+                resolve: {},
+                params: {
+                    param: '1',
+                },
+                rule: {
+                    path: 'panel-b/:param',
+                    component: TestPanelBComponent,
+                },
+                route: {
+                    segments: [new UrlSegment('panel-b', {}), new UrlSegment('1', {})],
+                    path: 'panel-b/1',
+                },
+            },
+            data: {},
+            linkableObjects: [],
+        };
+    }
+
+    function getOpenedPanelData(): NaturalPanelData[] {
+        return dialog.openDialogs.map(d => d.componentInstance.panelData);
+    }
+
+    describe('without fallback', () => {
+        beforeEach(async () => {
+            await configure(routesWithoutFallback);
+        });
+
+        it('can navigate to no-panels', fakeAsync(() => {
+            expect(rootFixture).not.toBeNull();
+            rootFixture.ngZone?.run(() => router.navigate(['no-panels']));
+            tick(100);
+
+            expect(rootComponent.routerOutlet.component).toBeInstanceOf(TestNoPanelComponent);
+            expect(getOpenedPanelData()).withContext('nothing opened yet').toEqual([]);
+        }));
+
+        it('can navigate to with-panels, then open panel A, then open panel B, then open panel A again', fakeAsync(() => {
+            expect(rootFixture).not.toBeNull();
+            rootFixture.ngZone?.run(() => router.navigate(['with-panels']));
+            tick(100);
+
+            expect(rootComponent.routerOutlet.component).toBeInstanceOf(TestWithPanelComponent);
+            expect(getOpenedPanelData()).withContext('nothing opened yet').toEqual([]);
+
+            // Open panel A 2
+            rootFixture.ngZone?.run(() => router.navigate(['with-panels', 'panel-a', '2']));
+            tick(100);
+
+            expect(getOpenedPanelData()).withContext('panel A 2 should have been opened').toEqual([panelA2]);
+
+            // Open panel A 3 with an URL which is **not** prefixed
+            rootFixture.ngZone?.run(() => router.navigate(['panel-a', '3']));
+            tick(100);
+
+            injectPanelCount(panelA3, '2'); // Also expect `pc` parameter
+            expect(getOpenedPanelData())
+                .withContext('panel A 3 should have been opened in addition of A 2')
+                .toEqual([panelA2, panelA3]);
+        }));
+
+        it('can deep navigate directly into sub-panels', fakeAsync(() => {
+            expect(rootFixture).not.toBeNull();
+            rootFixture.ngZone?.run(() =>
+                router.navigate(['with-panels', 'panel-a', '2', 'panel-a', '3', 'panel-b', '1']),
+            );
+            tick(100);
+
+            expect(rootComponent.routerOutlet.component).toBeInstanceOf(TestWithPanelComponent);
+            expect(getOpenedPanelData()).toEqual([panelA2, panelA3, panelB1]);
+        }));
+    });
+});

--- a/projects/natural/src/lib/modules/panels/public-api.ts
+++ b/projects/natural/src/lib/modules/panels/public-api.ts
@@ -6,5 +6,6 @@ export * from './panels.module';
 export * from './panels.component';
 export * from './panels.service';
 export {naturalPanelsUrlMatcher} from './panels.urlmatcher';
+export {fallbackIfNoOpenedPanels} from './fallback-if-no-opened-panels.urlmatcher';
 export * from './abstract-panel';
 export * from './types';

--- a/projects/natural/src/lib/modules/panels/types.ts
+++ b/projects/natural/src/lib/modules/panels/types.ts
@@ -52,7 +52,7 @@ export interface NaturalPanelResolve<T> {
  */
 export interface NaturalPanelsRouterRule {
     path: string;
-    component: ComponentType<any>;
+    component: ComponentType<NaturalAbstractPanel>;
     resolve?: {[key: string]: Type<NaturalPanelResolve<unknown>>};
 }
 

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,6 +1,6 @@
 import {NgModule} from '@angular/core';
 import {RouterModule, Routes} from '@angular/router';
-import {NaturalPanelsComponent, naturalPanelsUrlMatcher} from '@ecodev/natural';
+import {fallbackIfNoOpenedPanels, NaturalPanelsComponent, naturalPanelsUrlMatcher} from '@ecodev/natural';
 import {AnyResolver} from '../../projects/natural/src/lib/testing/any.resolver';
 import {EditableListComponent} from './editable-list/editable-list.component';
 import {HierarchicComponent} from './hierarchic/hierarchic.component';
@@ -142,10 +142,19 @@ const routes: Routes = [
             },
         ],
     },
+    {
+        // 404 redirects to home
+        matcher: fallbackIfNoOpenedPanels,
+        redirectTo: '',
+    },
 ];
 
 @NgModule({
-    imports: [RouterModule.forRoot(routes, {paramsInheritanceStrategy: 'always'})],
+    imports: [
+        RouterModule.forRoot(routes, {
+            paramsInheritanceStrategy: 'always',
+        }),
+    ],
     exports: [RouterModule],
 })
 export class AppRoutingModule {}

--- a/src/app/panels/panels.component.html
+++ b/src/app/panels/panels.component.html
@@ -3,5 +3,6 @@
 <div fxLayout="row" fxLayoutGap="10px">
     <a mat-flat-button routerLink="panel/1">Panel 1</a>
     <a mat-flat-button routerLink="panel/1/panel/2">Panel 1 & 2</a>
+    <a mat-flat-button routerLink="invalid-url">invalid url</a>
 </div>
 <router-outlet></router-outlet>

--- a/src/app/shared/components/any/any.component.html
+++ b/src/app/shared/components/any/any.component.html
@@ -1,6 +1,7 @@
 <div fxLayout="row" fxLayoutGap="10px">
     <a [routerLink]="['panel', '2']" mat-flat-button>Panel 2 (dynamic)</a>
     <a mat-flat-button routerLink="panel/3">Panel 3 (static)</a>
+    <a [routerLink]="['invalid-url']" mat-flat-button>invalid url</a>
 </div>
 
 <mat-tab-group [naturalLinkableTab]="false">


### PR DESCRIPTION
Angular routing uses `path: '**'` as fallback mechanism to catch all
404 and do something more useful than crash and burn.

With our panel panel system this was not possible anymore because
panels require to catch Angular navigation errors (to re-route them inside
panels) and thus adding `path: '**'` broke panel navigations.

So we introduce `matcher: fallbackIfNoOpenedPanels` as a replacement of
`path: '**'`. This allows Angular to fallback as usual when panels are not
opened. But as soon as at least one panel is opened, then Angular fallback
is not matched anymore and our panel routing takes over.

So the panel logic is almost untouched, but we "enable" it only when necessary.


<hr>

@sambaptista le code original a quasiment pas bougé finalement. Tout le principe de fonctionnement est conservé. C'est surtout un "helper" en plus. Néamoins, j'aimerais ton avis sur la PR avant de merger.

J'ai évidemment testé dans OKpilot aussi, et cela me semble fonctionner comme prévu, mais si jamais tu as des cas compliqué en tête hésite pas à tester plus...