### PR TITLE
NavigableList: can use pagination in a sublevel #8559

### DIFF
--- a/projects/natural/src/lib/classes/abstract-navigable-list.ts
+++ b/projects/natural/src/lib/classes/abstract-navigable-list.ts
@@ -134,7 +134,6 @@ export class NaturalAbstractNavigableList<
 
     public clearSearch(): void {
         this.naturalSearchSelections = [[]];
-        this.search([[]]);
         this.persistenceService.persistInStorage('ns', null, this.getStorageKey());
     }
 


### PR DESCRIPTION
When the user is navigating in a sublevel (parameter `na` set),
the paginator doesn't allow to access to a page > 0.

Fixes #158