### PR TITLE
New `timeAgo` pipe

### DIFF
--- a/projects/natural/src/lib/modules/common/common-module.ts
+++ b/projects/natural/src/lib/modules/common/common-module.ts
@@ -11,15 +11,17 @@ import {MatFormFieldModule} from '@angular/material/form-field';
 import {MatInputModule} from '@angular/material/input';
 import {MatSelectModule} from '@angular/material/select';
 import {NaturalSrcDensityDirective} from './directives/src-density.directive';
+import {NaturalTimeAgoPipe} from './pipes/time-ago.pipe';
 
 const declarationsToExport = [
     NaturalCapitalizePipe,
     NaturalEllipsisPipe,
     NaturalEnumPipe,
-    NaturalSwissDatePipe,
     NaturalHttpPrefixDirective,
-    NaturalSrcDensityDirective,
     NaturalLinkableTabDirective,
+    NaturalSrcDensityDirective,
+    NaturalSwissDatePipe,
+    NaturalTimeAgoPipe,
 ];
 
 @NgModule({

--- a/projects/natural/src/lib/modules/common/pipes/time-ago.pipe.spec.ts
+++ b/projects/natural/src/lib/modules/common/pipes/time-ago.pipe.spec.ts
@@ -1,0 +1,59 @@
+import {NaturalTimeAgoPipe} from './time-ago.pipe';
+
+describe('NaturalTimeAgoPipe', () => {
+    it('create an instance', () => {
+        const pipe = new NaturalTimeAgoPipe();
+        expect(pipe).toBeTruthy();
+    });
+
+    const cases: [string, string][] = [
+        // Past
+        ['2005-06-15T06:30:30', 'il y a 5 ans'],
+        ['2009-06-14T06:30:30', 'il y a un an'],
+        ['2010-04-13T06:30:30', 'il y a 2 mois'],
+        ['2010-05-14T06:30:30', 'il y a un mois'],
+        ['2010-05-31T06:30:30', 'il y a 2 semaines'],
+        ['2010-06-07T06:30:30', 'il y a une semaine'],
+        ['2010-06-13T06:30:30', 'il y a 2 jours'],
+        ['2010-06-14T06:30:30', 'il y a un jour'],
+        ['2010-06-15T03:30:30', 'il y a 3 heures'],
+        ['2010-06-15T05:30:30', 'il y a une heure'],
+        ['2010-06-15T06:15:30', 'il y a 15 minutes'],
+        ['2010-06-15T06:25:30', 'il y a 5 minutes'],
+        ['2010-06-15T06:29:30', 'il y a quelques minutes'],
+        ['2010-06-15T06:30:20', 'il y a quelques minutes'],
+        // Now ! Assumes nobody will actually read the text before a few seconds/minutes pass, so even "now" is a few minutes ago
+        ['2010-06-15T06:30:30', 'il y a quelques minutes'],
+        // Future
+        ['2010-06-15T06:30:31', 'dans quelques minutes'],
+        ['2010-06-15T06:32:40', 'dans quelques minutes'],
+        ['2010-06-15T06:35:31', 'dans 5 minutes'],
+        ['2010-06-15T06:45:30', 'dans 15 minutes'],
+        ['2010-06-15T07:30:31', 'dans une heure'],
+        ['2010-06-15T09:30:30', 'dans 3 heures'],
+        ['2010-06-16T06:30:31', 'dans un jour'],
+        ['2010-06-17T06:30:31', 'dans 2 jours'],
+        ['2010-06-22T06:30:31', 'dans une semaine'],
+        ['2010-06-29T06:30:31', 'dans 2 semaines'],
+        ['2010-07-16T06:30:31', 'dans un mois'],
+        ['2010-08-16T06:30:31', 'dans 2 mois'],
+        ['2011-06-15T06:30:31', 'dans un an'],
+        ['2012-06-15T06:30:30', 'dans 2 ans'],
+        ['2010-06-18', 'dans 3 jours'],
+    ];
+
+    cases.forEach(parameters => {
+        it('with ' + JSON.stringify(parameters), () => {
+            const pipe = new NaturalTimeAgoPipe(Date.parse('2010-06-15T06:30:30'));
+            expect(pipe.transform(new Date(parameters[0]))).toBe(parameters[1]);
+            expect(pipe.transform(parameters[0])).toBe(parameters[1]);
+        });
+    });
+
+    it('with empty value', () => {
+        const pipe = new NaturalTimeAgoPipe();
+        expect(pipe.transform(null)).toBe('');
+        expect(pipe.transform(undefined)).toBe('');
+        expect(pipe.transform('')).toBe('');
+    });
+});

--- a/projects/natural/src/lib/modules/common/pipes/time-ago.pipe.ts
+++ b/projects/natural/src/lib/modules/common/pipes/time-ago.pipe.ts
@@ -1,0 +1,109 @@
+import {Inject, Optional, Pipe, PipeTransform} from '@angular/core';
+
+function isDate(value: any): value is Date {
+    return value instanceof Date && !isNaN(value.valueOf());
+}
+
+/**
+ * Returns a string to approximately describe the date.
+ *
+ * Eg:
+ *
+ * - "il y a quelques minutes"
+ * - "dans 3 jours"
+ * - "dans 3 ans"
+ */
+@Pipe({
+    name: 'timeAgo',
+})
+export class NaturalTimeAgoPipe implements PipeTransform {
+    public constructor(
+        @Optional() @Inject('SHOULD_NEVER_BE_INJECTED') private readonly fakedNow: number | null = null,
+    ) {}
+
+    private getNow(): number {
+        return this.fakedNow ?? Date.now();
+    }
+
+    public transform(date: Date | string | null | undefined): string {
+        if (!date) {
+            return '';
+        }
+
+        const stamp = isDate(date) ? date.getTime() : Date.parse(date);
+        const now = this.getNow();
+
+        const $seconds = (stamp - now) / 1000;
+        const minutes = $seconds / 60;
+        const hours = minutes / 60;
+        const days = hours / 24;
+        const weeks = days / 7;
+        const months = days / 31;
+        const years = days / 365;
+
+        // Find out the best unit to use for display
+        if (years <= -2) {
+            const value = Math.round(Math.abs(years));
+            return $localize`il y a ${value} ans`;
+        } else if (years <= -1) {
+            return $localize`il y a un an`;
+        } else if (months <= -2) {
+            const value = Math.round(Math.abs(months));
+            return $localize`il y a ${value} mois`;
+        } else if (months <= -1) {
+            return $localize`il y a un mois`;
+        } else if (weeks <= -2) {
+            const value = Math.round(Math.abs(weeks));
+            return $localize`il y a ${value} semaines`;
+        } else if (weeks <= -1) {
+            return $localize`il y a une semaine`;
+        } else if (days <= -2) {
+            const value = Math.round(Math.abs(days));
+            return $localize`il y a ${value} jours`;
+        } else if (days <= -1) {
+            return $localize`il y a un jour`;
+        } else if (hours <= -2) {
+            const value = Math.round(Math.abs(hours));
+            return $localize`il y a ${value} heures`;
+        } else if (hours <= -1) {
+            return $localize`il y a une heure`;
+        } else if (minutes <= -5) {
+            const value = Math.round(Math.abs(minutes));
+            return $localize`il y a ${value} minutes`;
+        } else if (minutes <= 0) {
+            return $localize`il y a quelques minutes`;
+        } else if (years > 2) {
+            const value = Math.round(years);
+            return $localize`dans ${value} ans`;
+        } else if (years > 1) {
+            return $localize`dans un an`;
+        } else if (months > 2) {
+            const value = Math.round(months);
+            return $localize`dans ${value} mois`;
+        } else if (months > 1) {
+            return $localize`dans un mois`;
+        } else if (weeks > 2) {
+            const value = Math.round(weeks);
+            return $localize`dans ${value} semaines`;
+        } else if (weeks > 1) {
+            return $localize`dans une semaine`;
+        } else if (days > 2) {
+            const value = Math.round(days);
+            return $localize`dans ${value} jours`;
+        } else if (days > 1) {
+            return $localize`dans un jour`;
+        } else if (hours > 2) {
+            const value = Math.round(hours);
+            return $localize`dans ${value} heures`;
+        } else if (hours > 1) {
+            return $localize`dans une heure`;
+        } else if (minutes > 5) {
+            const value = Math.round(minutes);
+            return $localize`dans ${value} minutes`;
+        } else if (minutes > 0) {
+            return $localize`dans quelques minutes`;
+        } else {
+            throw new Error('Time travelling just happened');
+        }
+    }
+}

--- a/projects/natural/src/lib/modules/common/public-api.ts
+++ b/projects/natural/src/lib/modules/common/public-api.ts
@@ -8,6 +8,7 @@ export * from './pipes/capitalize.pipe';
 export * from './pipes/ellipsis.pipe';
 export * from './pipes/enum.pipe';
 export * from './pipes/swiss-date.pipe';
+export {NaturalTimeAgoPipe} from './pipes/time-ago.pipe';
 export * from './services/memory-storage';
 export {NaturalSrcDensityDirective} from './directives/src-density.directive';
 export {

--- a/projects/natural/src/lib/modules/hierarchic-selector/classes/model-node.ts
+++ b/projects/natural/src/lib/modules/hierarchic-selector/classes/model-node.ts
@@ -2,7 +2,7 @@ import {BehaviorSubject} from 'rxjs';
 import {NaturalHierarchicConfiguration} from './hierarchic-configuration';
 import {NameOrFullName} from '../../../types/types';
 
-export type HierarchicModel = {id: string; __typename: string} & NameOrFullName;
+export type HierarchicModel = {__typename: string} & NameOrFullName;
 
 export class HierarchicModelNode {
     public childrenChange: BehaviorSubject<HierarchicModelNode[]> = new BehaviorSubject<HierarchicModelNode[]>([]);

--- a/projects/natural/src/lib/modules/stamp/stamp-module.module.ts
+++ b/projects/natural/src/lib/modules/stamp/stamp-module.module.ts
@@ -1,10 +1,13 @@
-import {CommonModule} from '@angular/common';
 import {NgModule} from '@angular/core';
 import {NaturalStampComponent} from './stamp.component';
+import {CommonModule} from '@angular/common';
+import {NaturalCommonModule} from '../common/common-module';
+
+const declarationsToExport = [NaturalStampComponent];
 
 @NgModule({
-    declarations: [NaturalStampComponent],
-    imports: [CommonModule],
-    exports: [NaturalStampComponent],
+    declarations: [...declarationsToExport],
+    imports: [CommonModule, NaturalCommonModule],
+    exports: [...declarationsToExport],
 })
 export class NaturalStampModule {}

--- a/projects/natural/src/lib/modules/stamp/stamp.component.html
+++ b/projects/natural/src/lib/modules/stamp/stamp.component.html
@@ -7,7 +7,7 @@
         <span *ngIf="item.creationDate">{{ item.creationDate | swissDate }} ({{ item.creationDate | timeAgo }})</span>
     </div>
 
-    <div *ngIf="item.updateDate || item.updater">
+    <div *ngIf="showUpdate()">
         <span class="mat-body-2" i18n>Modification</span>
         :
         <span *ngIf="item.updater">{{ item.updater.fullName || item.updater.name }}</span>

--- a/projects/natural/src/lib/modules/stamp/stamp.component.html
+++ b/projects/natural/src/lib/modules/stamp/stamp.component.html
@@ -4,9 +4,7 @@
         :
         <span *ngIf="item.creator">{{ item.creator.fullName || item.creator.name }}</span>
         <span *ngIf="item.creator && item.creationDate">,&nbsp;</span>
-        <span *ngIf="item.creationDate"
-            >{{ item.creationDate | date: 'mediumDate' }} - {{ item.creationDate | date: 'shortTime' }}</span
-        >
+        <span *ngIf="item.creationDate">{{ item.creationDate | swissDate }} ({{ item.creationDate | timeAgo }})</span>
     </div>
 
     <div *ngIf="item.updateDate || item.updater">
@@ -14,8 +12,6 @@
         :
         <span *ngIf="item.updater">{{ item.updater.fullName || item.updater.name }}</span>
         <span *ngIf="item.updater && item.updateDate">,&nbsp;</span>
-        <span *ngIf="item.updateDate"
-            >{{ item.updateDate | date: 'mediumDate' }} - {{ item.updateDate | date: 'shortTime' }}</span
-        >
+        <span *ngIf="item.updateDate">{{ item.updateDate | swissDate }} ({{ item.updateDate | timeAgo }})</span>
     </div>
 </ng-container>

--- a/projects/natural/src/lib/modules/stamp/stamp.component.ts
+++ b/projects/natural/src/lib/modules/stamp/stamp.component.ts
@@ -14,4 +14,13 @@ type Stamped = {
 })
 export class NaturalStampComponent {
     @Input() public item!: Stamped;
+
+    public showUpdate(): boolean {
+        const same =
+            this.item.updater?.id === this.item.creator?.id &&
+            this.item.updateDate &&
+            this.item.updateDate === this.item.creationDate;
+
+        return !same && (!!this.item.updateDate || !!this.item.updater);
+    }
 }

--- a/projects/natural/src/lib/types/types.ts
+++ b/projects/natural/src/lib/types/types.ts
@@ -14,10 +14,12 @@ export interface Literal {
  */
 export type NameOrFullName =
     | {
+          id: string;
           name: string;
           fullName?: string;
       }
     | {
+          id: string;
           name?: string;
           fullName: string;
       };


### PR DESCRIPTION
In order to keep the implementation straightforward, we never update the result when time passes. So end-user should navigate again to same page to see the "refreshed" timeAgo.

This should be acceptable because our timeAgo is intentionally vague. Specifically the smallest unit is minutes, not seconds.

Fixes #53