### PR TITLE
NaturalEditor: support `id` and `class` attributes on headings and paragraphs

### DIFF
--- a/projects/natural-editor/src/lib/editor/editor.component.html
+++ b/projects/natural-editor/src/lib/editor/editor.component.html
@@ -125,11 +125,18 @@
 
             <button
                 mat-menu-item
-                *ngIf="menu.paragraphClass"
-                [disabled]="menu.paragraphClass.disabled"
-                (click)="run($event, 'paragraphClass')"
+                *ngIf="menu.blockClass"
+                [disabled]="menu.blockClass.disabled"
+                (click)="run($event, 'blockClass')"
                 i18n
                 >Classe...
+            </button>
+            <button
+                mat-menu-item
+                *ngIf="menu.blockId"
+                [disabled]="menu.blockId.disabled"
+                (click)="run($event, 'blockId')"
+                >ID...
             </button>
         </mat-menu>
 

--- a/projects/natural-editor/src/lib/utils/items/id-item.ts
+++ b/projects/natural-editor/src/lib/utils/items/id-item.ts
@@ -1,10 +1,11 @@
 import {Node, NodeType} from 'prosemirror-model';
 import {AllSelection, EditorState, TextSelection, Transaction} from 'prosemirror-state';
 import {Item} from './item';
+import {selectionContainsNodeType} from './utils';
 import {MatDialog} from '@angular/material/dialog';
 import {IdDialogComponent, IdDialogData} from '../../id-dialog/id-dialog.component';
 
-function setId(tr: Transaction, idValue: string, allowedNodeType: NodeType): Transaction {
+function setId(tr: Transaction, idValue: string, allowedNodeTypes: string[]): Transaction {
     const {selection, doc} = tr;
     if (!selection || !doc) {
         return tr;
@@ -20,7 +21,7 @@ function setId(tr: Transaction, idValue: string, allowedNodeType: NodeType): Tra
     doc.nodesBetween(from, to, (node, pos) => {
         const nodeType = node.type;
         const currentId = node.attrs.id || null;
-        if (currentId !== idValue && allowedNodeType === nodeType) {
+        if (currentId !== idValue && allowedNodeTypes.includes(nodeType.name)) {
             tasks.push({
                 node,
                 pos,
@@ -51,41 +52,40 @@ function setId(tr: Transaction, idValue: string, allowedNodeType: NodeType): Tra
  * Returns the first `id` attribute that is non-empty in the selection.
  * If not found, return empty string.
  */
-function findFirstIdInSelection(state: EditorState, allowedNodeType: NodeType): string {
+function findFirstIdInSelection(state: EditorState, allowedNodeTypes: string[]): string {
     const {selection, doc} = state;
     const {from, to} = selection;
     let keepLooking = true;
-    let foundClass: string = '';
+    let foundId: string = '';
 
     doc.nodesBetween(from, to, node => {
-        if (keepLooking && node.type === allowedNodeType && node.attrs.id) {
+        if (keepLooking && allowedNodeTypes.includes(node.type.name) && node.attrs.id) {
             keepLooking = false;
-            foundClass = node.attrs.id;
+            foundId = node.attrs.id;
         }
 
         return keepLooking;
     });
 
-    return foundClass;
+    return foundId;
 }
 
 export class IdItem extends Item {
-    public constructor(dialog: MatDialog, nodeType: NodeType) {
+    public constructor(dialog: MatDialog, nodeTypes: string[]) {
         super({
             active: state => {
-                return !!findFirstIdInSelection(state, nodeType);
+                return !!findFirstIdInSelection(state, nodeTypes);
             },
 
             enable: state => {
-                const {selection} = state;
-                return selection instanceof TextSelection || selection instanceof AllSelection;
+                return selectionContainsNodeType(state, nodeTypes);
             },
 
             run: (state, dispatch, view): void => {
                 dialog
                     .open<IdDialogComponent, IdDialogData, IdDialogData>(IdDialogComponent, {
                         data: {
-                            id: findFirstIdInSelection(state, nodeType),
+                            id: findFirstIdInSelection(state, nodeTypes),
                         },
                     })
                     .afterClosed()
@@ -93,7 +93,7 @@ export class IdItem extends Item {
                         if (dispatch && result) {
                             const {selection} = state;
 
-                            const tr = setId(state.tr.setSelection(selection), result.id, nodeType);
+                            const tr = setId(state.tr.setSelection(selection), result.id, nodeTypes);
                             if (tr.docChanged) {
                                 dispatch?.(tr);
                             }

--- a/projects/natural-editor/src/lib/utils/items/utils.ts
+++ b/projects/natural-editor/src/lib/utils/items/utils.ts
@@ -46,3 +46,21 @@ export function markTypeToItem(markType: MarkType): Item {
         },
     });
 }
+
+export function selectionContainsNodeType(state: EditorState, allowedNodeTypes: string[]): boolean {
+    const {selection, doc} = state;
+    const {from, to} = selection;
+    let keepLooking = true;
+    let found = false;
+
+    doc.nodesBetween(from, to, node => {
+        if (keepLooking && allowedNodeTypes.includes(node.type.name)) {
+            keepLooking = false;
+            found = true;
+        }
+
+        return keepLooking;
+    });
+
+    return found;
+}

--- a/projects/natural-editor/src/lib/utils/menu.ts
+++ b/projects/natural-editor/src/lib/utils/menu.ts
@@ -25,6 +25,7 @@ import {
 } from 'prosemirror-tables';
 import {Item} from './items/item';
 import {paragraphWithAlignment} from './schema/paragraph-with-alignment';
+import {heading} from './schema/heading';
 import {TextAlignItem} from './items/text-align-item';
 import {CellBackgroundColorItem} from './items/cell-background-color-item';
 import {LinkItem} from './items/link-item';
@@ -77,7 +78,8 @@ export type Key =
     | 'cellBackgroundColor'
     | 'tableClass'
     | 'tableId'
-    | 'paragraphClass';
+    | 'blockClass'
+    | 'blockId';
 
 export type MenuItems = Partial<Record<Key, Item>>;
 
@@ -139,7 +141,6 @@ export function buildMenuItems(schema: Schema, dialog: MatDialog): MenuItems {
             r.alignRight = new TextAlignItem('right');
             r.alignCenter = new TextAlignItem('center');
             r.alignJustify = new TextAlignItem('justify');
-            r.paragraphClass = new ClassItem(dialog, type);
         }
     }
 
@@ -156,6 +157,10 @@ export function buildMenuItems(schema: Schema, dialog: MatDialog): MenuItems {
         r.makeHead4 = menuItemToItem(blockTypeItem(type, {attrs: {level: 4}}));
         r.makeHead5 = menuItemToItem(blockTypeItem(type, {attrs: {level: 5}}));
         r.makeHead6 = menuItemToItem(blockTypeItem(type, {attrs: {level: 6}}));
+    }
+    if (schema.nodes.paragraph?.spec === paragraphWithAlignment) {
+        r.blockId = new IdItem(dialog, ['heading', 'paragraph']);
+        r.blockClass = new ClassItem(dialog, ['heading', 'paragraph']);
     }
 
     type = schema.nodes.horizontal_rule;
@@ -179,8 +184,8 @@ export function buildMenuItems(schema: Schema, dialog: MatDialog): MenuItems {
         r.toggleHeaderRow = cmdToItem(toggleHeaderRow);
         r.toggleHeaderCell = cmdToItem(toggleHeaderCell);
         r.cellBackgroundColor = new CellBackgroundColorItem(dialog);
-        r.tableClass = new ClassItem(dialog, type);
-        r.tableId = new IdItem(dialog, type);
+        r.tableClass = new ClassItem(dialog, ['table']);
+        r.tableId = new IdItem(dialog, ['table']);
     }
 
     return r;

--- a/projects/natural-editor/src/lib/utils/schema/heading.ts
+++ b/projects/natural-editor/src/lib/utils/schema/heading.ts
@@ -1,0 +1,76 @@
+import {Attrs, NodeSpec} from 'prosemirror-model';
+
+type Attributes = {
+    class: string;
+    id: null | string;
+    level: number;
+};
+
+const getAttrsForLevel = function (level: number): (node: HTMLElement | string) => Attrs | false | null {
+    return (dom: Node | string): null | Attributes => {
+        if (!(dom instanceof HTMLElement)) {
+            return null;
+        }
+        const id = dom.getAttribute('id') || null;
+        const attrs: Attributes = {level: level, class: dom.className, id: id};
+
+        return attrs;
+    };
+};
+
+/**
+ * A heading textblock, with a `level` attribute that should hold the number 1 to 6,
+ * with optional ID and class attributes. Parsed and serialized as `<h1>` to <h6>`
+ *
+ * https://github.com/ProseMirror/prosemirror-schema-basic/blob/master/src/schema-basic.js
+ */
+export const heading: NodeSpec = {
+    attrs: {
+        level: {default: 1},
+        class: {default: null},
+        id: {default: null},
+    },
+    content: 'inline*',
+    group: 'block',
+    defining: true,
+    parseDOM: [
+        {
+            tag: 'h1',
+            getAttrs: getAttrsForLevel(1),
+        },
+        {
+            tag: 'h2',
+            getAttrs: getAttrsForLevel(2),
+        },
+        {
+            tag: 'h3',
+            getAttrs: getAttrsForLevel(3),
+        },
+        {
+            tag: 'h4',
+            getAttrs: getAttrsForLevel(4),
+        },
+        {
+            tag: 'h5',
+            getAttrs: getAttrsForLevel(5),
+        },
+        {
+            tag: 'h6',
+            getAttrs: getAttrsForLevel(6),
+        },
+    ],
+    toDOM: node => {
+        const {id} = node.attrs;
+        const attrs: {[key: string]: string} = {};
+
+        if (id) {
+            attrs.id = id;
+        }
+
+        if (node.attrs.class) {
+            attrs.class = node.attrs.class;
+        }
+
+        return ['h' + node.attrs.level, attrs, 0];
+    },
+};

--- a/projects/natural-editor/src/lib/utils/schema/schema.ts
+++ b/projects/natural-editor/src/lib/utils/schema/schema.ts
@@ -2,6 +2,7 @@ import {marks, nodes} from 'prosemirror-schema-basic';
 import {addListNodes} from 'prosemirror-schema-list';
 import {Schema} from 'prosemirror-model';
 import {paragraphWithAlignment} from './paragraph-with-alignment';
+import {heading} from './heading';
 import {tableNodes} from './table';
 
 // Keep only basic elements
@@ -31,6 +32,7 @@ export const basicSchema = new Schema({
 const tmpSchema2 = new Schema({
     nodes: {
         ...nodes,
+        heading: heading,
         ...tableNodes({
             tableGroup: 'block',
             cellContent: 'block+',

--- a/src/app/editor/editor.component.ts
+++ b/src/app/editor/editor.component.ts
@@ -29,11 +29,15 @@ export class EditorComponent {
     <li>item 1</li>
     <li>item 2</li>
     <li>item 3</li>
-</ul>`;
+</ul>
+<h2 class="my-title-class" id="chapter2">Title Level2 green italic</h2>
+`;
 
     public readonly css = `
     .my-paragraph-class {background: pink}
     .my-table-class tr:nth-child(even) {background: darkgreen}
+    .my-title-class {color: green}
+    #chapter2 {font-style: italic}
     #myTable tr th {color: #2a7ae2}
     @media screen and (min-width: 900px) {
        .my-paragraph-class {color: red}


### PR DESCRIPTION
This add DOM parsing and generation capabilities as well as advanced editor buttons to edit `id` and `class` attributes on heading (`<h1>` to `<h6>`) and paragraphs (`<p>`) nodes.

In the editor type menu, ID and Class buttons can set the attributes on both headings and paragraphs, depending on the current selection.

For exemple one can generate: 

``` html
<h1 id="chapter1" class="chapter">Chapter 1</h1>
<p id="intro1" class="intro">Welcome to a new chapter</p>
```
![image](https://user-images.githubusercontent.com/869941/198293029-4ab712f0-88eb-4a58-96b2-e24435c70e59.png)
