### PR TITLE
Date facet has a `today` feature

### DIFF
--- a/projects/natural/src/lib/modules/dropdown-components/type-date/type-date.component.html
+++ b/projects/natural/src/lib/modules/dropdown-components/type-date/type-date.component.html
@@ -1,5 +1,5 @@
 <form [formGroup]="form">
-    <mat-form-field style="max-width: 4em; margin-right: 1em">
+    <mat-form-field>
         <mat-label i18n="Mathematical operator < > =">Opérateur</mat-label>
         <mat-select [formControl]="operatorCtrl" [required]="true">
             <mat-option *ngFor="let item of operators" [value]="item.key">
@@ -26,4 +26,6 @@
             <span *ngIf="valueCtrl.hasError('required')">*</span>
         </mat-error>
     </mat-form-field>
+
+    <mat-checkbox [formControl]="todayCtrl" i18n>Aujourd'hui</mat-checkbox>
 </form>

--- a/projects/natural/src/lib/modules/dropdown-components/type-date/type-date.component.scss
+++ b/projects/natural/src/lib/modules/dropdown-components/type-date/type-date.component.scss
@@ -1,0 +1,19 @@
+form {
+    display: grid;
+    grid: auto auto / 4em auto;
+    grid-gap: 0 1em;
+}
+
+form > * {
+    // Otherwise bottom line of mat-select is not aligned with mat-input
+    // TODO check if this is still necessary after migration to MDC: https://material.angular.io/guide/mdc-migration
+    align-self: end;
+}
+
+form > mat-checkbox {
+    grid-column-start: 2;
+
+    // Prevent scroll bar
+    // TODO idem
+    margin-bottom: 0.3em;
+}

--- a/projects/natural/src/lib/modules/dropdown-components/type-date/type-date.component.spec.ts
+++ b/projects/natural/src/lib/modules/dropdown-components/type-date/type-date.component.spec.ts
@@ -1,11 +1,11 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
-
 import {DateAdapter, MAT_DATE_LOCALE, MatNativeDateModule, NativeDateAdapter} from '@angular/material/core';
 import {MatDatepickerModule} from '@angular/material/datepicker';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {MatInputModule} from '@angular/material/input';
 import {MatSelectModule} from '@angular/material/select';
+import {MatCheckboxModule} from '@angular/material/checkbox';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {
     FilterGroupConditionField,
@@ -57,6 +57,32 @@ describe('TypeDateComponent', () => {
         less: {value: '2019-09-09'},
     };
 
+    const conditionGreaterOrEqualToday: FilterGroupConditionField = {
+        greaterOrEqual: {value: 'today'},
+    };
+
+    const conditionLessOrEqualToday: FilterGroupConditionField = {
+        lessOrEqual: {value: 'today'},
+    };
+
+    const conditionGreaterToday: FilterGroupConditionField = {
+        greater: {value: 'today'},
+    };
+
+    const conditionLessToday: FilterGroupConditionField = {
+        less: {value: 'today'},
+    };
+
+    const conditionEqualToday: FilterGroupConditionField = {
+        greaterOrEqual: {value: 'today'},
+        less: {value: 'tomorrow'},
+    };
+
+    const conditionInvalidRangeEqualToday: FilterGroupConditionField = {
+        greaterOrEqual: {value: 'today'},
+        less: {value: '2019-09-09'}, // the date will be transparently fixed into "tomorrow"
+    };
+
     const config: TypeDateConfiguration<Date> = {};
 
     const configWithRules: TypeDateConfiguration<Date> = {
@@ -76,6 +102,7 @@ describe('TypeDateComponent', () => {
                 MatSelectModule,
                 MatDatepickerModule,
                 MatNativeDateModule,
+                MatCheckboxModule,
             ],
             providers: [
                 {
@@ -108,6 +135,8 @@ describe('TypeDateComponent', () => {
 
     it('should create', () => {
         createComponent(null, null);
+        expect(component.todayCtrl.value).toBeFalse();
+        expect(component.valueCtrl.enabled).toBeTrue();
         expect(component).toBeTruthy();
     });
 
@@ -115,21 +144,29 @@ describe('TypeDateComponent', () => {
         const empty: FilterGroupConditionField = {};
 
         createComponent(null, null);
+        expect(component.todayCtrl.value).toBeFalse();
+        expect(component.valueCtrl.enabled).toBeTrue();
         expect(component.getCondition()).toEqual(empty);
     });
 
     it('should get `greaterOrEqual` condition with config', () => {
         createComponent(conditionGreaterOrEqual, config);
+        expect(component.todayCtrl.value).toBeFalse();
+        expect(component.valueCtrl.enabled).toBeTrue();
         expect(component.getCondition()).toEqual(conditionGreaterOrEqual);
     });
 
     it('should get `greaterOrEqual` condition with config with rules', () => {
         createComponent(conditionGreaterOrEqual, configWithRules);
+        expect(component.todayCtrl.value).toBeFalse();
+        expect(component.valueCtrl.enabled).toBeTrue();
         expect(component.getCondition()).toEqual(conditionGreaterOrEqual);
     });
 
     it('should get condition with config with rules and automatically change to greaterOrEqual', () => {
         createComponent(conditionGreater, configWithRules);
+        expect(component.todayCtrl.value).toBeFalse();
+        expect(component.valueCtrl.enabled).toBeTrue();
         expect(component.getCondition()).toEqual({
             greaterOrEqual: {value: '2012-01-06'},
         });
@@ -137,6 +174,8 @@ describe('TypeDateComponent', () => {
 
     it('should get `less` condition with config with rules', () => {
         createComponent(conditionLessOrEqual, configWithRules);
+        expect(component.todayCtrl.value).toBeFalse();
+        expect(component.valueCtrl.enabled).toBeTrue();
         expect(component.getCondition())
             .withContext('should automatically change to less')
             .toEqual({
@@ -146,66 +185,179 @@ describe('TypeDateComponent', () => {
 
     it('should get `less` condition with config with rules', () => {
         createComponent(conditionLess, configWithRules);
+        expect(component.todayCtrl.value).toBeFalse();
+        expect(component.valueCtrl.enabled).toBeTrue();
         expect(component.getCondition()).toEqual(conditionLess);
     });
 
     it('should get `equal` condition with config with rules', () => {
         createComponent(conditionEqual, configWithRules);
+        expect(component.todayCtrl.value).toBeFalse();
+        expect(component.valueCtrl.enabled).toBeTrue();
         expect(component.getCondition()).toEqual(conditionEqual);
     });
 
     it('should get `equal` condition with config with rules because it transparently accept invalid range and fix it', () => {
         createComponent(conditionInvalidRangeEqual, configWithRules);
+        expect(component.todayCtrl.value).toBeFalse();
+        expect(component.valueCtrl.enabled).toBeTrue();
         expect(component.getCondition()).toEqual(conditionEqual);
     });
 
     it('should render `null` as empty string', () => {
         createComponent(null, null);
+        expect(component.todayCtrl.value).toBeFalse();
+        expect(component.valueCtrl.enabled).toBeTrue();
         expect(component.renderedValue.value).toBe('');
     });
 
     it('should render `greaterOrEqual` value as string', () => {
         createComponent(conditionGreaterOrEqual, config);
+        expect(component.todayCtrl.value).toBeFalse();
+        expect(component.valueCtrl.enabled).toBeTrue();
         expect(component.renderedValue.value).toBe('≥ 05/01/2012');
     });
 
     it('should render `greaterOrEqual` value as string with config with rules', () => {
         createComponent(conditionGreaterOrEqual, configWithRules);
+        expect(component.todayCtrl.value).toBeFalse();
+        expect(component.valueCtrl.enabled).toBeTrue();
         expect(component.renderedValue.value).toBe('≥ 05/01/2012');
     });
 
     it('should render `greater` value as string', () => {
         createComponent(conditionGreater, configWithRules);
+        expect(component.todayCtrl.value).toBeFalse();
+        expect(component.valueCtrl.enabled).toBeTrue();
         expect(component.renderedValue.value).toBe('> 05/01/2012');
     });
 
     it('should render `lessOrEqual` value as string', () => {
         createComponent(conditionLessOrEqual, configWithRules);
+        expect(component.todayCtrl.value).toBeFalse();
+        expect(component.valueCtrl.enabled).toBeTrue();
         expect(component.renderedValue.value).toBe('≤ 05/01/2018');
     });
 
     it('should render `less` value as string', () => {
         createComponent(conditionLess, configWithRules);
+        expect(component.todayCtrl.value).toBeFalse();
+        expect(component.valueCtrl.enabled).toBeTrue();
         expect(component.renderedValue.value).toBe('< 05/01/2018');
     });
 
     it('should render `equal` value as string', () => {
         createComponent(conditionEqual, configWithRules);
+        expect(component.todayCtrl.value).toBeFalse();
+        expect(component.valueCtrl.enabled).toBeTrue();
         expect(component.renderedValue.value).toBe('= 05/01/2018');
     });
 
     it('should not validate without value', () => {
         createComponent(null, null);
+        expect(component.todayCtrl.value).toBeFalse();
+        expect(component.valueCtrl.enabled).toBeTrue();
         expect(component.isValid()).toBe(false);
     });
 
     it('should validate with value but without rules', () => {
         createComponent(conditionGreaterOrEqual, config);
+        expect(component.todayCtrl.value).toBeFalse();
+        expect(component.valueCtrl.enabled).toBeTrue();
         expect(component.isValid()).toBe(true);
     });
 
     it('should not validate with value with rules', () => {
         createComponent(conditionGreaterOrEqual, configWithRules);
+        expect(component.todayCtrl.value).toBeFalse();
+        expect(component.valueCtrl.enabled).toBeTrue();
         expect(component.isValid()).toBe(false);
+    });
+
+    describe('supports special "today" value', () => {
+        it('should get `lessOrEqual` condition', () => {
+            createComponent(conditionLessOrEqualToday, config);
+            expect(component.todayCtrl.value).toBeTrue();
+            expect(component.valueCtrl.enabled).toBeFalse();
+            expect(component.getCondition())
+                .withContext(
+                    'should *not* automatically change to `less` because we would not be able to reload a consistent GUI with those values',
+                )
+                .toEqual(conditionLessOrEqualToday);
+        });
+
+        it('should get `great` condition', () => {
+            createComponent(conditionGreaterToday, config);
+            expect(component.todayCtrl.value).toBeTrue();
+            expect(component.valueCtrl.enabled).toBeFalse();
+            expect(component.getCondition())
+                .withContext(
+                    'should *not* automatically change to `greaterOrEqual` because we would not be able to reload a consistent GUI with those values',
+                )
+                .toEqual(conditionGreaterToday);
+        });
+
+        it('should get `less` condition', () => {
+            createComponent(conditionLessToday, config);
+            expect(component.todayCtrl.value).toBeTrue();
+            expect(component.valueCtrl.enabled).toBeFalse();
+            expect(component.getCondition()).toEqual(conditionLessToday);
+        });
+
+        it('should get `equal` condition', () => {
+            createComponent(conditionEqualToday, config);
+            expect(component.todayCtrl.value).toBeTrue();
+            expect(component.valueCtrl.enabled).toBeFalse();
+            expect(component.getCondition()).toEqual(conditionEqualToday);
+        });
+
+        it('should get `equal` condition because it transparently accept invalid range and fix it', () => {
+            createComponent(conditionInvalidRangeEqualToday, config);
+            expect(component.todayCtrl.value).toBeTrue();
+            expect(component.valueCtrl.enabled).toBeFalse();
+            expect(component.getCondition()).toEqual(conditionEqualToday);
+        });
+
+        it('should get `greaterOrEqual` condition', () => {
+            createComponent(conditionGreaterOrEqualToday, config);
+            expect(component.todayCtrl.value).toBeTrue();
+            expect(component.valueCtrl.enabled).toBeFalse();
+            expect(component.getCondition()).toEqual(conditionGreaterOrEqualToday);
+        });
+
+        it('should render `equal` for as string', () => {
+            createComponent(conditionEqualToday, config);
+            expect(component.todayCtrl.value).toBeTrue();
+            expect(component.valueCtrl.enabled).toBeFalse();
+            expect(component.renderedValue.value).toBe("= Aujourd'hui");
+        });
+
+        it('should render `greaterOrEqual` value as string', () => {
+            createComponent(conditionGreaterOrEqualToday, config);
+            expect(component.todayCtrl.value).toBeTrue();
+            expect(component.valueCtrl.enabled).toBeFalse();
+            expect(component.renderedValue.value).toBe("≥ Aujourd'hui");
+        });
+
+        it('should render `lessOrEqual` value as string', () => {
+            createComponent(conditionLessOrEqualToday, config);
+            expect(component.todayCtrl.value).toBeTrue();
+            expect(component.valueCtrl.enabled).toBeFalse();
+            expect(component.renderedValue.value).toBe("≤ Aujourd'hui");
+        });
+
+        it('should render `less` value as string', () => {
+            createComponent(conditionLessToday, config);
+            expect(component.todayCtrl.value).toBeTrue();
+            expect(component.valueCtrl.enabled).toBeFalse();
+            expect(component.renderedValue.value).toBe("< Aujourd'hui");
+        });
+
+        it('should render `greater` value as string', () => {
+            createComponent(conditionGreaterToday, config);
+            expect(component.todayCtrl.value).toBeTrue();
+            expect(component.valueCtrl.enabled).toBeFalse();
+            expect(component.renderedValue.value).toBe("> Aujourd'hui");
+        });
     });
 });

--- a/projects/natural/src/lib/modules/hierarchic-selector/hierarchic-selector/hierarchic-selector.service.ts
+++ b/projects/natural/src/lib/modules/hierarchic-selector/hierarchic-selector/hierarchic-selector.service.ts
@@ -15,6 +15,7 @@ import {
 } from '../classes/hierarchic-filters-configuration';
 import {HierarchicModel, HierarchicModelNode} from '../classes/model-node';
 import {Literal} from '../../../types/types';
+import {FilterGroupCondition} from '../../search/classes/graphql-doctrine.types';
 
 export interface OrganizedModelSelection {
     [key: string]: any[];
@@ -267,7 +268,7 @@ export class NaturalHierarchicSelectorService {
         contextFilter: HierarchicFilterConfiguration['filter'] | null = null,
         allDeeps = false,
     ): HierarchicFilterConfiguration['filter'] | null {
-        const fieldCondition: Literal = {};
+        const fieldCondition: FilterGroupCondition = {};
 
         // if no parent, filter empty elements
         if (!flatNode) {

--- a/projects/natural/src/lib/modules/search/classes/graphql-doctrine.spec.ts
+++ b/projects/natural/src/lib/modules/search/classes/graphql-doctrine.spec.ts
@@ -1,4 +1,4 @@
-import {NaturalSearchFacets, toGraphQLDoctrineFilter} from '@ecodev/natural';
+import {formatIsoDate, NaturalSearchFacets, toGraphQLDoctrineFilter, TypeDateComponent} from '@ecodev/natural';
 import {NaturalSearchSelection, NaturalSearchSelections} from '../types/values';
 import {Filter, LogicalOperator} from './graphql-doctrine.types';
 
@@ -425,5 +425,42 @@ describe('toGraphQLDoctrineFilter', () => {
         const expected: Filter = {};
 
         expect(toGraphQLDoctrineFilter(flagFacets, input)).toEqual(expected);
+    });
+
+    it('should handle `TypeDateComponent` with special "today" value', () => {
+        const facetWithDate: NaturalSearchFacets = [
+            {
+                display: 'Creation date',
+                field: 'creationDate',
+                component: TypeDateComponent,
+            },
+        ];
+
+        const input: NaturalSearchSelections = [
+            [
+                {
+                    field: 'creationDate',
+                    condition: {
+                        less: {
+                            value: 'today',
+                        },
+                    },
+                },
+            ],
+        ];
+
+        const expected: Filter = {
+            groups: [
+                {
+                    conditions: [
+                        {
+                            creationDate: {less: {value: formatIsoDate(new Date())}} as any,
+                        },
+                    ],
+                },
+            ],
+        };
+
+        expect(toGraphQLDoctrineFilter(facetWithDate, input)).toEqual(expected);
     });
 });

--- a/projects/natural/src/lib/modules/search/classes/transformers.spec.ts
+++ b/projects/natural/src/lib/modules/search/classes/transformers.spec.ts
@@ -1,5 +1,6 @@
-import {replaceOperatorByField, replaceOperatorByName, wrapLike} from '@ecodev/natural';
+import {formatIsoDate, replaceOperatorByField, replaceOperatorByName, wrapLike} from '@ecodev/natural';
 import {NaturalSearchSelection} from '../types/values';
+import {replaceToday} from './transformers';
 
 describe('wrapLike', () => {
     it('should add % around like value', () => {
@@ -48,5 +49,75 @@ describe('replaceOperatorByName', () => {
         };
 
         expect(replaceOperatorByName(input)).toEqual(expected);
+    });
+});
+
+describe('replaceToday', () => {
+    const date = new Date();
+    const today = formatIsoDate(date);
+
+    date.setDate(date.getDate() + 1);
+    const tomorrow = formatIsoDate(date);
+
+    it('should replace `< "today"` by `< real today`', () => {
+        const input: NaturalSearchSelection = {
+            field: 'myFieldName',
+            condition: {less: {value: 'today'}},
+        };
+
+        const expected: NaturalSearchSelection = {
+            field: 'myFieldName',
+            condition: {less: {value: today}},
+        };
+
+        expect(replaceToday(input)).toEqual(expected);
+    });
+
+    it('should replace `≤ "today"` by `< real tomorrow` date and change operator', () => {
+        const input: NaturalSearchSelection = {
+            field: 'myFieldName',
+            condition: {lessOrEqual: {value: 'today'}},
+        };
+
+        const expected: NaturalSearchSelection = {
+            field: 'myFieldName',
+            condition: {less: {value: tomorrow}},
+        };
+
+        expect(replaceToday(input)).toEqual(expected);
+    });
+
+    it('should replace `> "today"` by `≥ real tomorrow` date and change operator', () => {
+        const input: NaturalSearchSelection = {
+            field: 'myFieldName',
+            condition: {greater: {value: 'today'}},
+        };
+
+        const expected: NaturalSearchSelection = {
+            field: 'myFieldName',
+            condition: {greaterOrEqual: {value: tomorrow}},
+        };
+
+        expect(replaceToday(input)).toEqual(expected);
+    });
+
+    it('should replace "today" and "tomorrow" by real today date everywhere', () => {
+        const input: NaturalSearchSelection = {
+            field: 'myFieldName',
+            condition: {
+                greaterOrEqual: {value: 'today'},
+                less: {value: 'tomorrow'},
+            },
+        };
+
+        const expected: NaturalSearchSelection = {
+            field: 'myFieldName',
+            condition: {
+                greaterOrEqual: {value: today},
+                less: {value: tomorrow},
+            },
+        };
+
+        expect(replaceToday(input)).toEqual(expected);
     });
 });

--- a/projects/natural/src/lib/modules/search/classes/transformers.ts
+++ b/projects/natural/src/lib/modules/search/classes/transformers.ts
@@ -1,4 +1,5 @@
 import {NaturalSearchSelection} from '../types/values';
+import {formatIsoDate} from '../../../classes/utility';
 
 /**
  * Wrap the searched value by `%` SQL wildcard
@@ -64,6 +65,58 @@ function replaceOperatorByAttribute(
 
     selection.condition[attributeValue] = selection.condition[oldOperator];
     delete selection.condition[oldOperator];
+
+    return selection;
+}
+
+/**
+ * Replace `"today"` and `"tomorrow"` by their real value right now.
+ *
+ * This transformer is applied automatically and should **not** be part
+ * of Natural public API.
+ *
+ * So:
+ *
+ *     {field: 'myFieldName', condition: {greater: {value: 'today'}}}
+ *
+ * will become
+ *
+ *     {field: 'myFieldName', condition: {greater: {value: '2023-01-03'}}}
+ */
+export function replaceToday(selection: NaturalSearchSelection): NaturalSearchSelection {
+    const date = new Date();
+    const today = formatIsoDate(date);
+
+    date.setDate(date.getDate() + 1);
+    const tomorrow = formatIsoDate(date);
+
+    // Transparently adapt exclusive/inclusive ranges for special "today" value.
+    // Ideally this should be done in `TypeDateComponent`, like it is done for real date values. But unfortunately I
+    // could not find a reasonable way to do that while still being able to reload a coherent GUI without showing
+    // "Demain" somewhere in the GUI. And that is something we want to avoid, we only want to show either "Aujourd'hui"
+    // or a real date. Otherwise, the human would start thinking with "Demain", and it would then need to be properly
+    // supported which over/complexify the code, the GUI and the workflow.
+    const condition = selection.condition;
+    if (Object.keys(condition).length === 1) {
+        if (condition.lessOrEqual?.value === 'today') {
+            delete condition.lessOrEqual;
+            condition.less = {value: 'tomorrow'};
+        } else if (condition.greater?.value === 'today') {
+            delete condition.greater;
+            condition.greaterOrEqual = {value: 'tomorrow'};
+        }
+    }
+
+    for (const key in condition) {
+        const operator = condition[key];
+        if (operator && 'value' in operator) {
+            if (operator.value === 'today') {
+                operator.value = today;
+            } else if (operator.value === 'tomorrow') {
+                operator.value = tomorrow;
+            }
+        }
+    }
 
     return selection;
 }

--- a/projects/natural/src/lib/modules/search/public-api.ts
+++ b/projects/natural/src/lib/modules/search/public-api.ts
@@ -11,5 +11,5 @@ export {NATURAL_DROPDOWN_DATA} from './dropdown-container/dropdown.service';
 export {NaturalSearchModule} from './search.module';
 export {toGraphQLDoctrineFilter} from './classes/graphql-doctrine';
 export {fromUrl, toUrl, toNavigationParameters} from './classes/url';
-export * from './classes/transformers';
+export {replaceOperatorByName, wrapLike, replaceOperatorByField} from './classes/transformers';
 export {NaturalSearchComponent} from './search/search.component';

--- a/src/app/demo.error-handler.ts
+++ b/src/app/demo.error-handler.ts
@@ -8,7 +8,7 @@ export class DemoLoggerExtra implements NaturalLoggerExtra {
     public constructor(private readonly snackBar: MatSnackBar) {}
 
     public getExtras(error: unknown): Observable<Partial<NaturalLoggerType>> {
-        this.snackBar.open('You failed', 'Yes', {
+        this.snackBar.open('An error happened', 'Yes', {
             duration: 3000,
             panelClass: ['snackbar-error'],
             verticalPosition: 'top',


### PR DESCRIPTION
This makes "today" special value a relative value that is stored as-is in URL and local storage. And it is only converted to real date juste before sending to server. So filters including "today" can be bookmarked forever and used everyday.