### PR TITLE
Natural declares its own typography #9432

### DIFF
--- a/projects/natural/src/lib/_natural.theme.scss
+++ b/projects/natural/src/lib/_natural.theme.scss
@@ -1,3 +1,5 @@
+@use '@angular/material' as mat;
+
 // Non themes
 @use 'styles/layout';
 @use 'styles/table';
@@ -18,9 +20,19 @@
     @include file.natural-file($theme);
 }
 
-.mdc-button {
-    letter-spacing: normal !important;
-}
+$defaultConfig: mat.define-typography-config();
+
+// This is the default Material typography, but with button with normal letter-spacing instead of wider letter-spacing.
+$typography: mat.define-typography-config(
+    $button:
+        mat.define-typography-level(
+            $font-family: mat.font-family($defaultConfig, 'button'),
+            $font-weight: mat.font-weight($defaultConfig, 'button'),
+            $font-size: mat.font-size($defaultConfig, 'button'),
+            $line-height: mat.line-height($defaultConfig, 'button'),
+            $letter-spacing: normal,
+        ),
+);
 
 span {
     -webkit-font-smoothing: antialiased;

--- a/projects/natural/theming/_natural.theme.scss
+++ b/projects/natural/theming/_natural.theme.scss
@@ -7,4 +7,4 @@ So Natural styles can be imported into an application like so:
 ```
  */
 
-@forward '../src/lib/natural.theme' show natural;
+@forward '../src/lib/natural.theme' show natural, $typography;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -124,6 +124,7 @@ $light-theme: mat.define-light-theme(
             accent: $theme-accent,
             warn: $theme-warn,
         ),
+        typography: natural.$typography,
     )
 );
 $dark-theme: mat.define-dark-theme(


### PR DESCRIPTION
It's mostly the same as the default Material, with the only exception of
 button's letter-spacing.

Cela veut dire qu'il faudra l'utiliser explicitement dans nos projets, comme visible dans la demo. Mais cela me semble tout à fait propre.

@sambaptista qu'en dis-tu ?