### PR TITLE
Columns picker support buttons #8670

### DIFF
--- a/projects/natural/src/lib/classes/abstract-list.ts
+++ b/projects/natural/src/lib/classes/abstract-list.ts
@@ -413,8 +413,8 @@ export class NaturalAbstractList<
     }
 
     /**
-     * Header is always visible in non-panel context
-     * Is hidden when no results in panels
+     * In non-panel context, header is always visible.
+     * In panel context, header is hidden when no results.
      */
     public showHeader(): boolean {
         return !this.isPanel || (this.isPanel && this.showTable());

--- a/projects/natural/src/lib/modules/columns-picker/columns-picker.component.html
+++ b/projects/natural/src/lib/modules/columns-picker/columns-picker.component.html
@@ -1,5 +1,142 @@
 <div>
-    <mat-menu #naturalMenu="matMenu">
+    <ng-container *ngIf="isMobile | async; else elseBlock">
+        <button mat-icon-button [matMenuTriggerFor]="mobileMenu">
+            <mat-icon naturalIcon="more_vert"></mat-icon>
+        </button>
+
+        <mat-menu #mobileMenu="matMenu">
+            <ng-template matMenuContent>
+                <ng-container *ngFor="let button of buttons">
+                    <a
+                        mat-menu-item
+                        *ngIf="button.href"
+                        [href]="defaultTrue(button.show) && button.href"
+                        (click)="button.click?.(button, $event)"
+                        [disabled]="button.disabled"
+                        [ngClass]="needMargin(button)"
+                    >
+                        <mat-checkbox *ngIf="useCheckbox(button)" [checked]="button.checked"></mat-checkbox>
+
+                        {{ button.label }}
+                    </a>
+
+                    <button
+                        mat-menu-item
+                        *ngIf="defaultTrue(button.show) && !button.href && !button.buttons"
+                        (click)="button.click?.(button, $event)"
+                        [disabled]="button.disabled"
+                        [ngClass]="needMargin(button)"
+                    >
+                        <mat-checkbox *ngIf="useCheckbox(button)" [checked]="button.checked"></mat-checkbox>
+
+                        {{ button.label }}
+                    </button>
+
+                    <ng-container *ngIf="defaultTrue(button.show) && button.buttons">
+                        <button
+                            mat-menu-item
+                            [matMenuTriggerFor]="subMenu"
+                            (click)="button.click?.(button, $event)"
+                            [ngClass]="needMargin(button)"
+                        >
+                            <mat-checkbox *ngIf="useCheckbox(button)" [checked]="button.checked"></mat-checkbox>
+
+                            {{ button.label }}
+                        </button>
+
+                        <mat-menu #subMenu="matMenu">
+                            <ng-template matMenuContent>
+                                <a
+                                    *ngFor="let subButton of button.buttons"
+                                    mat-menu-item
+                                    [disabled]="subButton.disabled"
+                                    (click)="subButton.click(subButton, $event)"
+                                >
+                                    {{ subButton.label }}
+                                </a>
+                            </ng-template>
+                        </mat-menu>
+                    </ng-container>
+                </ng-container>
+
+                <button
+                    *ngIf="displayedColumns.length"
+                    [matMenuTriggerFor]="columnMenu"
+                    mat-menu-item
+                    [ngClass]="needMargin(null)"
+                >
+                    <span i18n>Colonnes</span>
+                </button>
+            </ng-template>
+        </mat-menu>
+    </ng-container>
+
+    <ng-template #elseBlock>
+        <ng-container *ngFor="let button of buttons">
+            <a
+                mat-icon-button
+                *ngIf="button.href"
+                [href]="defaultTrue(button.show) && button.href"
+                (click)="button.click?.(button, $event)"
+                [disabled]="button.disabled"
+                [color]="color(button)"
+                [matTooltip]="button.label"
+            >
+                <mat-icon [naturalIcon]="button.icon"></mat-icon>
+            </a>
+
+            <button
+                mat-icon-button
+                *ngIf="defaultTrue(button.show) && !button.href && !button.buttons"
+                (click)="button.click?.(button, $event)"
+                [disabled]="button.disabled"
+                [color]="color(button)"
+                [matTooltip]="button.label"
+            >
+                <mat-icon [naturalIcon]="button.icon"></mat-icon>
+            </button>
+
+            <ng-container *ngIf="defaultTrue(button.show) && button.buttons">
+                <button
+                    mat-icon-button
+                    [matMenuTriggerFor]="menu"
+                    (click)="button.click?.(button, $event)"
+                    [disabled]="button.disabled"
+                    [color]="color(button)"
+                    [matTooltip]="button.label"
+                >
+                    <mat-icon [naturalIcon]="button.icon"></mat-icon>
+                </button>
+
+                <mat-menu #menu="matMenu">
+                    <ng-template matMenuContent>
+                        <a
+                            *ngFor="let subButton of button.buttons"
+                            mat-menu-item
+                            [disabled]="subButton.disabled"
+                            (click)="subButton.click(subButton, $event)"
+                        >
+                            {{ subButton.label }}
+                        </a>
+                    </ng-template>
+                </mat-menu>
+            </ng-container>
+        </ng-container>
+
+        <button
+            *ngIf="displayedColumns.length"
+            [matMenuTriggerFor]="columnMenu"
+            mat-icon-button
+            i18n-matTooltip
+            matTooltip="Sélectionner les colonnes"
+        >
+            <mat-icon naturalIcon="view_column"></mat-icon>
+        </button>
+    </ng-template>
+</div>
+
+<mat-menu #columnMenu="matMenu">
+    <ng-template matMenuContent>
         <div
             (click)="$event.stopPropagation(); column.checked = !column.checked; updateColumns()"
             *ngFor="let column of displayedColumns"
@@ -9,8 +146,5 @@
                 column.label
             }}</mat-checkbox>
         </div>
-    </mat-menu>
-    <button [matMenuTriggerFor]="naturalMenu" mat-icon-button i18n-matTooltip matTooltip="Sélectionner les colonnes">
-        <mat-icon naturalIcon="view_column"></mat-icon>
-    </button>
-</div>
+    </ng-template>
+</mat-menu>

--- a/projects/natural/src/lib/modules/columns-picker/columns-picker.component.html
+++ b/projects/natural/src/lib/modules/columns-picker/columns-picker.component.html
@@ -1,5 +1,5 @@
 <div>
-    <ng-container *ngIf="isMobile | async; else elseBlock">
+    <ng-container *ngIf="(isMobile | async) && someVisibleButtons(); else elseBlock">
         <button mat-icon-button [matMenuTriggerFor]="mobileMenu">
             <mat-icon naturalIcon="more_vert"></mat-icon>
         </button>

--- a/projects/natural/src/lib/modules/columns-picker/columns-picker.component.scss
+++ b/projects/natural/src/lib/modules/columns-picker/columns-picker.component.scss
@@ -1,0 +1,3 @@
+.align-with-checkbox {
+    padding-left: 61px; // Magic number to align menu item without checkboxes with menu items with checkboxes
+}

--- a/projects/natural/src/lib/modules/columns-picker/columns-picker.component.ts
+++ b/projects/natural/src/lib/modules/columns-picker/columns-picker.component.ts
@@ -1,15 +1,21 @@
 import {Component, EventEmitter, Input, OnChanges, OnDestroy, Output, SimpleChanges} from '@angular/core';
-import {AvailableColumn} from './types';
+import {AvailableColumn, Button} from './types';
 import {cancellableTimeout} from '../../classes/rxjs';
-import {Subject} from 'rxjs';
+import {map, Subject} from 'rxjs';
+import {ThemePalette} from '@angular/material/core';
+import {BreakpointObserver, Breakpoints} from '@angular/cdk/layout';
 
 @Component({
     selector: 'natural-columns-picker',
     templateUrl: './columns-picker.component.html',
+    styleUrls: ['./columns-picker.component.scss'],
 })
 export class NaturalColumnsPickerComponent implements OnChanges, OnDestroy {
     private _selections?: string[];
     private _availableColumns: Required<AvailableColumn>[] = [];
+
+    @Input()
+    public buttons: Readonly<Readonly<Button>[]> | null = [];
 
     /**
      * Set all the columns that are available.
@@ -59,6 +65,10 @@ export class NaturalColumnsPickerComponent implements OnChanges, OnDestroy {
 
     private readonly ngUnsubscribe = new Subject<void>();
 
+    public readonly isMobile = this.breakpointObserver.observe(Breakpoints.XSmall).pipe(map(result => result.matches));
+
+    public constructor(private readonly breakpointObserver: BreakpointObserver) {}
+
     private initColumns(): void {
         this._availableColumns?.forEach(col => {
             col.checked = this._selections?.length ? this._selections.includes(col.id) : col.checked;
@@ -88,5 +98,23 @@ export class NaturalColumnsPickerComponent implements OnChanges, OnDestroy {
                 this.updateColumns();
             }
         });
+    }
+
+    public defaultTrue(value: boolean | undefined): boolean {
+        return value ?? true;
+    }
+
+    public color(button: Button): ThemePalette | null {
+        return button.checked ? 'primary' : null;
+    }
+
+    public useCheckbox(button: Button): boolean {
+        return 'checked' in button;
+    }
+
+    public needMargin(button: Button | null = null): string {
+        return this.buttons?.some(this.useCheckbox) && (!button || !this.useCheckbox(button))
+            ? 'align-with-checkbox'
+            : '';
     }
 }

--- a/projects/natural/src/lib/modules/columns-picker/columns-picker.component.ts
+++ b/projects/natural/src/lib/modules/columns-picker/columns-picker.component.ts
@@ -117,4 +117,10 @@ export class NaturalColumnsPickerComponent implements OnChanges, OnDestroy {
             ? 'align-with-checkbox'
             : '';
     }
+
+    public someVisibleButtons(): boolean {
+        const visibleButtons = this.buttons?.reduce((sum, button) => (this.defaultTrue(button.show) ? 1 : 0), 0) ?? 0;
+
+        return visibleButtons > 0;
+    }
 }

--- a/projects/natural/src/lib/modules/columns-picker/public-api.ts
+++ b/projects/natural/src/lib/modules/columns-picker/public-api.ts
@@ -2,6 +2,6 @@
  * Public API Surface of natural
  */
 
-export {AvailableColumn} from './types';
+export {AvailableColumn, Button, SubButton} from './types';
 export * from './columns-picker.component';
 export * from './columns-picker.module';

--- a/projects/natural/src/lib/modules/columns-picker/types.ts
+++ b/projects/natural/src/lib/modules/columns-picker/types.ts
@@ -31,3 +31,68 @@ export type AvailableColumn = {
      */
     hidden?: boolean;
 };
+
+/**
+ * A button that will be shown as an icon on desktop, or as a menu entry on mobile
+ */
+export type Button = {
+    /**
+     * On desktop will be shown as tooltip, or as menu entry on mobile
+     */
+    label: string;
+
+    /**
+     * The icon name to be used on desktop
+     */
+    icon: string;
+
+    /**
+     * Whether to show the button at all. Defaults to `true`.
+     */
+    show?: boolean;
+
+    /**
+     * Whether the button is disabled. Defaults to `false`.
+     */
+    disabled?: boolean;
+
+    /**
+     * A checked button will have a highlight color as an icon, or a check mark as menu entry. Defaults to `false`.
+     */
+    checked?: boolean;
+
+    /**
+     * The callback to call when button was clicked.
+     */
+    click?: (button: Button, event: Event) => void;
+
+    /**
+     * Rarely used, only for OKpilot where we want to show proper URL, but click is actually intercepted to show dialog
+     */
+    href?: string;
+
+    /**
+     * A non-empty list of sub-buttons (only 2 levels is supported).
+     */
+    buttons?: SubButton[];
+};
+
+/**
+ * A sub-button that will (always) be shown as a sub-menu entry
+ */
+export type SubButton = {
+    /**
+     * Label for menu entry
+     */
+    label: string;
+
+    /**
+     * Whether the button is disabled. Defaults to `false`.
+     */
+    disabled?: boolean;
+
+    /**
+     * The callback to call when button was clicked.
+     */
+    click: (subButton: SubButton, event: Event) => void;
+};

--- a/projects/natural/src/lib/modules/search/search.module.ts
+++ b/projects/natural/src/lib/modules/search/search.module.ts
@@ -16,6 +16,7 @@ import {NaturalGroupComponent} from './group/group.component';
 import {NaturalInputComponent} from './input/input.component';
 import {NaturalSearchComponent} from './search/search.component';
 import {MatIconModule} from '@angular/material/icon';
+import {MatTooltipModule} from '@angular/material/tooltip';
 
 @NgModule({
     declarations: [
@@ -28,16 +29,17 @@ import {MatIconModule} from '@angular/material/icon';
     exports: [NaturalSearchComponent],
     imports: [
         CommonModule,
-        ReactiveFormsModule,
-        MatInputModule,
         MatButtonModule,
+        MatIconModule,
+        MatInputModule,
+        MatListModule,
         MatMenuModule,
         MatRippleModule,
-        PortalModule,
-        OverlayModule,
-        MatListModule,
+        MatTooltipModule,
         NaturalIconModule,
-        MatIconModule,
+        OverlayModule,
+        PortalModule,
+        ReactiveFormsModule,
     ],
     providers: [
         {

--- a/projects/natural/src/lib/modules/search/search/search.component.html
+++ b/projects/natural/src/lib/modules/search/search/search.component.html
@@ -1,4 +1,4 @@
-<div class="natural-search">
+<div class="natural-search" [ngClass]="{mobile: isMobile | async, hasMultipleGroups: innerSelections.length > 1}">
     <div class="groupsWrapper">
         <ng-container *ngFor="let groupSelections of innerSelections; let i = index; let last = last">
             <div class="groupWrapper">
@@ -9,29 +9,41 @@
                     [selections]="groupSelections"
                 ></natural-group>
 
-                <div class="endOfRowButton inGroup">
-                    <button (click)="removeGroup(i)" *ngIf="innerSelections.length > 1" mat-icon-button>
+                <div class="endOfRowButton">
+                    <button
+                        (click)="removeGroup(i)"
+                        *ngIf="innerSelections.length > 1"
+                        mat-icon-button
+                        i18n-matTooltip
+                        matTooltip="Supprimer ce groupe"
+                    >
                         <mat-icon naturalIcon="remove"></mat-icon>
                     </button>
                 </div>
-
-                <div class="endOfRowButton inGroup">
-                    <button (click)="addGroup()" *ngIf="last && multipleGroups" mat-icon-button>
-                        <mat-icon naturalIcon="add"></mat-icon>
-                    </button>
-                </div>
-
-                <!-- Spaceholder to keep fields alignment (prevent to push until end of line)--->
-                <div *ngIf="!last" class="spacer"></div>
             </div>
             <mat-divider *ngIf="!last"></mat-divider>
         </ng-container>
     </div>
 
-    <div class="endOfRowButton outOfGroup">
-        <button (click)="clear()" mat-icon-button>
+    <div class="endOfRowButton">
+        <button
+            (click)="addGroup()"
+            *ngIf="multipleGroups"
+            mat-icon-button
+            i18n-matTooltip
+            matTooltip="Ajouter un groupe"
+        >
+            <mat-icon naturalIcon="add"></mat-icon>
+        </button>
+
+        <button
+            (click)="clear()"
+            mat-icon-button
+            class="clear-button"
+            i18n-matTooltip
+            matTooltip="Annuler la recherche"
+        >
             <mat-icon naturalIcon="close"></mat-icon>
         </button>
-        <ng-content></ng-content>
     </div>
 </div>

--- a/projects/natural/src/lib/modules/search/search/search.component.scss
+++ b/projects/natural/src/lib/modules/search/search/search.component.scss
@@ -1,47 +1,56 @@
-:host {
-    .natural-search {
+.natural-search {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-end;
+
+    .groupsWrapper {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+        min-width: 0;
+    }
+
+    .groupWrapper {
         display: flex;
         flex-direction: row;
-        align-items: flex-end;
+        margin-bottom: 10px;
+        min-width: 0;
 
-        .groupsWrapper {
-            display: flex;
-            flex-direction: column;
+        natural-group {
             flex: 1;
-            min-width: 0;
+            max-width: 100%;
         }
 
-        .groupWrapper {
-            display: flex;
-            flex-direction: row;
-            margin-bottom: 10px;
-            min-width: 0;
-
-            natural-group {
-                flex: 1;
-                max-width: 100%;
-            }
-
-            &:last-of-type {
-                margin-bottom: 0;
-            }
-
-            .spacer {
-                width: 40px;
-                height: 40px;
-            }
+        &:last-of-type {
+            margin-bottom: 0;
         }
+    }
+
+    .endOfRowButton {
+        height: 53px;
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        margin-bottom: 15px;
+    }
+
+    mat-divider {
+        margin: -10px 0 10px 0;
+    }
+}
+
+.natural-search.mobile {
+    .clear-button {
+        display: none;
+    }
+
+    &.hasMultipleGroups {
+        flex-direction: column;
+        align-items: stretch;
 
         .endOfRowButton {
-            height: 53px;
-            display: flex;
-            flex-direction: row;
-            align-items: center;
-            margin-bottom: 10px;
-        }
-
-        mat-divider {
-            margin: -10px 10px 10px 0;
+            flex-direction: row-reverse;
+            margin-bottom: 0;
         }
     }
 }

--- a/projects/natural/src/lib/modules/search/search/search.component.ts
+++ b/projects/natural/src/lib/modules/search/search/search.component.ts
@@ -2,6 +2,8 @@ import {Component, EventEmitter, Input, OnChanges, Output} from '@angular/core';
 import {deepClone} from '../classes/utils';
 import {NaturalSearchFacets} from '../types/facet';
 import {GroupSelections, NaturalSearchSelections} from '../types/values';
+import {BreakpointObserver, Breakpoints} from '@angular/cdk/layout';
+import {map} from 'rxjs';
 
 @Component({
     selector: 'natural-search',
@@ -41,6 +43,10 @@ export class NaturalSearchComponent implements OnChanges {
     public set selections(selections: NaturalSearchSelections) {
         this.innerSelections = selections && selections[0] ? deepClone(selections) : [[]];
     }
+
+    public readonly isMobile = this.breakpointObserver.observe(Breakpoints.XSmall).pipe(map(result => result.matches));
+
+    public constructor(private readonly breakpointObserver: BreakpointObserver) {}
 
     public ngOnChanges(): void {
         if (!this.facets) {

--- a/src/app/list/list.component.html
+++ b/src/app/list/list.component.html
@@ -1,10 +1,14 @@
 <h1 class="mat-headline-4">NaturalAbstractList</h1>
 
 <div *ngIf="dataSource" fxFlex fxLayout="column">
-    <div fxLayout="column">
-        <div class="mat-headline-6 no-margin" fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="5px">{{
-            routeData?.title
-        }}</div>
+    <div fxLayout="row">
+        <div class="mat-headline-6 no-margin" fxFlex>{{ routeData?.title }}</div>
+        <natural-columns-picker
+            [availableColumns]="availableColumns"
+            [selections]="selectedColumns"
+            (selectionChange)="selectColumns($event)"
+            [buttons]="buttons"
+        />
     </div>
 
     <div fxLayout="column">
@@ -15,14 +19,7 @@
                 [multipleGroups]="true"
                 [selections]="naturalSearchSelections"
                 fxFlex
-            >
-                <natural-columns-picker
-                    [availableColumns]="availableColumns"
-                    [selections]="selectedColumns"
-                    (selectionChange)="selectColumns($event)"
-                >
-                </natural-columns-picker>
-            </natural-search>
+            />
         </div>
 
         <div class="responsive-table">

--- a/src/app/list/list.component.ts
+++ b/src/app/list/list.component.ts
@@ -1,5 +1,5 @@
 import {Component, Injector, OnInit} from '@angular/core';
-import {AvailableColumn, NaturalAbstractList, Sorting, SortingOrder} from '@ecodev/natural';
+import {AvailableColumn, Button, NaturalAbstractList, Sorting, SortingOrder} from '@ecodev/natural';
 import {ItemService} from '../../../projects/natural/src/lib/testing/item.service';
 
 @Component({
@@ -31,6 +31,45 @@ export class ListComponent extends NaturalAbstractList<ItemService> implements O
             id: 'hidden',
             label: 'hidden in menu',
             hidden: true,
+        },
+    ];
+
+    public readonly buttons: Button[] = [
+        {
+            label: 'Button with nothing',
+            icon: 'favorite',
+        },
+        {
+            label: 'Button with callback',
+            icon: 'forest',
+            click: console.log,
+        },
+        {
+            label: 'Button with href',
+            icon: 'diamond',
+            href: '/',
+        },
+        {
+            label: 'Button with check',
+            icon: 'check',
+            checked: false,
+            click: (button: Button): void => {
+                button.checked = !button.checked;
+            },
+        },
+        {
+            label: 'Button with sub-buttons',
+            icon: 'bolt',
+            buttons: [
+                {
+                    label: 'My sub-button 1',
+                    click: console.log,
+                },
+                {
+                    label: 'My sub-button 2',
+                    click: console.log,
+                },
+            ],
         },
     ];
 


### PR DESCRIPTION
Columns picker support a list of buttons, and sub-buttons. Those will be shown as icons on desktop, and as a textual menu on mobile.

# Desktop

![image](https://user-images.githubusercontent.com/72603/233676527-c96b332f-9b00-42af-885d-93a1fd10b49a.png)


# Samsung S8

![image](https://user-images.githubusercontent.com/72603/233676913-1d2b7d36-1841-46b0-bdcc-0714a7bfb2bb.png)
