### PR TITLE
BREAKING Typed `NaturalAbstractDetail.data` #9819

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
         "prosemirror-view": "^1.31.5",
         "rxjs": "^7.8.1",
         "tslib": "^2.5.3",
+        "type-fest": "^4.2.0",
         "zone.js": "~0.13.1"
     },
     "devDependencies": {

--- a/projects/natural-editor/tsconfig.lib.json
+++ b/projects/natural-editor/tsconfig.lib.json
@@ -7,7 +7,7 @@
         "declarationMap": true,
         "inlineSources": true,
         "types": [],
-        "lib": ["dom", "es2018"]
+        "lib": ["dom", "ES2022"]
     },
     "exclude": ["src/test.ts", "**/*.spec.ts"]
 }

--- a/projects/natural/src/lib/classes/abstract-editable-list.ts
+++ b/projects/natural/src/lib/classes/abstract-editable-list.ts
@@ -75,7 +75,7 @@ export class NaturalAbstractEditableList<
      */
     public addItems(items: readonly T[]): void {
         items.forEach(item => {
-            const completedItem = merge(this.service.getConsolidatedForClient(), item);
+            const completedItem = merge(this.service.getDefaultForServer(), item);
             const lineFormGroup = this.service.getFormGroup(completedItem);
             this.formArray.push(lineFormGroup);
         });

--- a/projects/natural/src/lib/classes/validators.spec.ts
+++ b/projects/natural/src/lib/classes/validators.spec.ts
@@ -1,13 +1,4 @@
-import {
-    available,
-    decimal,
-    deliverableEmail,
-    ifValid,
-    integer,
-    NaturalAbstractModelService,
-    unique,
-    urlValidator,
-} from '@ecodev/natural';
+import {available, decimal, deliverableEmail, ifValid, integer, unique, urlValidator} from '@ecodev/natural';
 import {
     AsyncValidatorFn,
     FormControl,
@@ -19,6 +10,7 @@ import {
 import {TestScheduler} from 'rxjs/testing';
 import {concat, forkJoin, NEVER, Observable, of, Subject, tap} from 'rxjs';
 import {first} from 'rxjs/operators';
+import {UntypedModelService} from '../types/types';
 
 function validate(validatorFn: ValidatorFn, expected: boolean, value: any): void {
     const control = new FormControl();
@@ -97,9 +89,7 @@ describe('unique', () => {
 
     cases.forEach(parameters => {
         it('with ' + JSON.stringify(parameters), done => {
-            const service = jasmine.createSpyObj<
-                NaturalAbstractModelService<any, any, any, any, any, any, any, any, any, any>
-            >('NaturalAbstractModelService', ['count']);
+            const service = jasmine.createSpyObj<UntypedModelService>('NaturalAbstractModelService', ['count']);
             service.count.and.returnValue(concat(of(parameters[1]), parameters[2] ? NEVER : NEVER));
 
             const validator = unique('id', null, service);

--- a/projects/natural/src/lib/classes/validators.ts
+++ b/projects/natural/src/lib/classes/validators.ts
@@ -10,15 +10,15 @@ import {
 } from '@angular/forms';
 import {Observable, of, timer} from 'rxjs';
 import {filter, first, map, switchMap} from 'rxjs/operators';
-import {NaturalAbstractModelService} from '../services/abstract-model.service';
 import {NaturalQueryVariablesManager, QueryVariables} from './query-variable-manager';
 import {validTlds} from './tld';
 import {FilterGroupCondition} from '../modules/search/classes/graphql-doctrine.types';
+import {UntypedModelService} from '../types/types';
 
 /**
  * Returns an async validator function that checks that the form control value is unique
  */
-export function unique<TService extends NaturalAbstractModelService<any, any, any, any, any, any, any, any, any, any>>(
+export function unique<TService extends UntypedModelService>(
     fieldName: string,
     excludedId: string | null | undefined,
     modelService: TService,

--- a/projects/natural/src/lib/modules/common/public-api.ts
+++ b/projects/natural/src/lib/modules/common/public-api.ts
@@ -18,5 +18,6 @@ export {
     NaturalSeoBasic,
     NaturalSeoResolve,
     NaturalSeoCallback,
+    NaturalSeoResolveData,
 } from './services/seo.service';
 export {provideSeo} from './services/seo.provider';

--- a/projects/natural/src/lib/modules/common/services/seo.service.ts
+++ b/projects/natural/src/lib/modules/common/services/seo.service.ts
@@ -42,6 +42,17 @@ export type NaturalSeoResolve = Robots & {
  */
 export type NaturalSeoCallback = (routeData: Data) => NaturalSeoBasic;
 
+/**
+ * Typically used to type the routing data received in the component, eg:
+ *
+ * ```ts
+ * class MyComponent extends NaturalAbstractDetail<MyService, NaturalSeoResolveData> {}
+ * ```
+ */
+export type NaturalSeoResolveData = {
+    seo: NaturalSeoBasic;
+};
+
 interface Robots {
     /**
      * If given will be used as robots meta tag, otherwise fallback on default value

--- a/projects/natural/src/lib/modules/dropdown-components/type-hierarchic-selector/type-hierarchic-selector.component.ts
+++ b/projects/natural/src/lib/modules/dropdown-components/type-hierarchic-selector/type-hierarchic-selector.component.ts
@@ -1,7 +1,6 @@
 import {Component} from '@angular/core';
 import {NaturalQueryVariablesManager} from '../../../classes/query-variable-manager';
-import {NaturalAbstractModelService} from '../../../services/abstract-model.service';
-import {Literal} from '../../../types/types';
+import {UntypedModelService, Literal} from '../../../types/types';
 import {NaturalHierarchicConfiguration} from '../../hierarchic-selector/classes/hierarchic-configuration';
 import {OrganizedModelSelection} from '../../hierarchic-selector/hierarchic-selector/hierarchic-selector.service';
 import {FilterGroupConditionField} from '../../search/classes/graphql-doctrine.types';
@@ -24,7 +23,7 @@ export type HierarchicFiltersConfiguration<T = Literal> = Array<HierarchicFilter
 
 export interface TypeHierarchicSelectorConfiguration {
     key: string;
-    service: NaturalAbstractModelService<any, any, any, any, any, any, any, any, any, any>;
+    service: UntypedModelService;
     config: NaturalHierarchicConfiguration[];
     filters?: HierarchicFiltersConfiguration;
 }

--- a/projects/natural/src/lib/modules/dropdown-components/type-natural-select/type-natural-select.component.ts
+++ b/projects/natural/src/lib/modules/dropdown-components/type-natural-select/type-natural-select.component.ts
@@ -1,7 +1,6 @@
 import {Component} from '@angular/core';
-import {NaturalAbstractModelService} from '../../../services/abstract-model.service';
 import {FilterGroupConditionField} from '../../search/classes/graphql-doctrine.types';
-import {ExtractTone, ExtractVall} from '../../../types/types';
+import {ExtractTone, ExtractVall, UntypedModelService} from '../../../types/types';
 import {AbstractAssociationSelectComponent} from '../abstract-association-select-component.directive';
 import {EMPTY, Observable} from 'rxjs';
 import {NaturalSelectComponent} from '../../select/select/select.component';
@@ -11,9 +10,7 @@ import {MatSelectModule} from '@angular/material/select';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 
-export interface TypeSelectNaturalConfiguration<
-    TService extends NaturalAbstractModelService<any, any, any, any, any, any, any, any, any, any>,
-> {
+export interface TypeSelectNaturalConfiguration<TService extends UntypedModelService> {
     service: TService;
     placeholder: string;
     filter?: ExtractVall<TService>['filter'];
@@ -33,7 +30,7 @@ export interface TypeSelectNaturalConfiguration<
     ],
 })
 export class TypeNaturalSelectComponent<
-    TService extends NaturalAbstractModelService<any, any, any, any, any, any, any, any, any, any>,
+    TService extends UntypedModelService,
 > extends AbstractAssociationSelectComponent<TypeSelectNaturalConfiguration<TService>> {
     public getCondition(): FilterGroupConditionField {
         if (!this.isValid()) {

--- a/projects/natural/src/lib/modules/hierarchic-selector/classes/hierarchic-configuration.ts
+++ b/projects/natural/src/lib/modules/hierarchic-selector/classes/hierarchic-configuration.ts
@@ -1,10 +1,8 @@
 import {Type} from '@angular/core';
 import {QueryVariables} from '../../../classes/query-variable-manager';
-import {NaturalAbstractModelService} from '../../../services/abstract-model.service';
+import {UntypedModelService} from '../../../types/types';
 
-type GenericModelService = NaturalAbstractModelService<any, any, any, any, any, any, any, any, any, any>;
-
-export interface NaturalHierarchicConfiguration<T extends GenericModelService = GenericModelService> {
+export interface NaturalHierarchicConfiguration<T extends UntypedModelService = UntypedModelService> {
     /**
      * An AbstractModelService to be used to fetch items
      */
@@ -66,7 +64,7 @@ export interface NaturalHierarchicConfiguration<T extends GenericModelService = 
     displayWith?: (item: any) => string;
 }
 
-export interface NaturalHierarchicServiceConfiguration<T extends GenericModelService = GenericModelService>
+export interface NaturalHierarchicServiceConfiguration<T extends UntypedModelService = UntypedModelService>
     extends NaturalHierarchicConfiguration<T> {
     injectedService: T;
 }

--- a/projects/natural/src/lib/testing/item.service.ts
+++ b/projects/natural/src/lib/testing/item.service.ts
@@ -20,6 +20,8 @@ export interface Item {
     readonly parent: Item | null;
 }
 
+export type ItemInput = Omit<Item, '__typename' | 'id'>;
+
 @Injectable({
     providedIn: 'root',
 })
@@ -29,9 +31,9 @@ export class ItemService extends NaturalAbstractModelService<
     PaginatedData<Item>,
     QueryVariables,
     Item,
-    {input: Item},
+    {input: ItemInput},
     Item,
-    {id: string; input: Literal},
+    {id: string; input: Partial<ItemInput>},
     boolean,
     {ids: string[]}
 > {
@@ -103,7 +105,7 @@ export class ItemService extends NaturalAbstractModelService<
         return of(this.getItem(true, 2, id));
     }
 
-    protected override getDefaultForClient(): Literal {
+    protected override getFormExtraFieldDefaultValues(): Literal {
         return {
             name: '',
             description: '',

--- a/projects/natural/src/lib/testing/null.service.ts
+++ b/projects/natural/src/lib/testing/null.service.ts
@@ -26,7 +26,7 @@ export class NullService extends NaturalAbstractModelService<
         super(apollo, naturalDebounceService, 'user', null, null, createPost, null, null);
     }
 
-    protected override getDefaultForServer(): PostInput {
+    public override getDefaultForServer(): PostInput {
         return {
             slug: '',
             blog: '',

--- a/projects/natural/src/lib/testing/post.service.ts
+++ b/projects/natural/src/lib/testing/post.service.ts
@@ -25,7 +25,7 @@ export class PostService extends NaturalAbstractModelService<
         super(apollo, naturalDebounceService, 'post', postQuery, postsQuery, createPost, updatePost, deletePosts);
     }
 
-    protected override getDefaultForServer(): PostInput {
+    public override getDefaultForServer(): PostInput {
         return {
             slug: '',
             blog: '',

--- a/projects/natural/src/lib/types/types.ts
+++ b/projects/natural/src/lib/types/types.ts
@@ -1,6 +1,7 @@
 import {PaginatedData} from '../classes/data-source';
 import {NaturalAbstractModelService, VariablesWithInput} from '../services/abstract-model.service';
 import {QueryVariables} from '../classes/query-variable-manager';
+import {ObservedValueOf} from 'rxjs';
 
 /**
  * An object literal with any keys and values
@@ -235,3 +236,16 @@ export type ExtractVdelete<P> = P extends NaturalAbstractModelService<
         ? Vdelete
         : never
     : never;
+
+/**
+ * Extract the resolve type from a NaturalAbstractModelService
+ */
+export type ExtractResolve<P> = P extends NaturalAbstractModelService<any, any, any, any, any, any, any, any, any, any>
+    ? ObservedValueOf<ReturnType<P['resolve']>>
+    : never;
+
+/**
+ * This should be avoided if possible, and instead use a more precise type with some constraints on it to ensure that the model
+ * service is able to fulfill its requirements.
+ */
+export type UntypedModelService = NaturalAbstractModelService<any, any, any, any, any, any, any, any, any, any>;

--- a/projects/natural/src/public-api.ts
+++ b/projects/natural/src/public-api.ts
@@ -25,7 +25,22 @@ export * from './lib/services/link-mutation.service';
 export {NaturalPersistenceService, NATURAL_PERSISTENCE_VALIDATOR} from './lib/services/persistence.service';
 export * from './lib/services/swiss-parsing-date-adapter.service';
 
-export * from './lib/types/types';
+export {
+    Literal,
+    NameOrFullName,
+    ExtractTone,
+    ExtractVone,
+    ExtractTall,
+    ExtractTallOne,
+    ExtractVall,
+    ExtractTcreate,
+    ExtractVcreate,
+    ExtractTupdate,
+    ExtractVupdate,
+    ExtractTdelete,
+    ExtractVdelete,
+    ExtractResolve,
+} from './lib/types/types';
 
 export * from './lib/modules/alert/public-api';
 export * from './lib/modules/columns-picker/public-api';

--- a/projects/natural/tsconfig.lib.json
+++ b/projects/natural/tsconfig.lib.json
@@ -5,7 +5,7 @@
         "declaration": true,
         "inlineSources": true,
         "types": [],
-        "lib": ["dom", "es2018"],
+        "lib": ["dom", "ES2022"],
         "declarationMap": true
     },
     "angularCompilerOptions": {

--- a/src/app/detail/detail.component.html
+++ b/src/app/detail/detail.component.html
@@ -27,7 +27,7 @@
                         <input matInput formControlName="description" (change)="update()" />
                     </mat-form-field>
 
-                    <button (click)="data.model.id = 123" color="primary" mat-raised-button
+                    <button (click)="data.model.id = '123'" color="primary" mat-raised-button
                         >Set ID to test delete button
                     </button>
                 </div>

--- a/src/app/detail/detail.component.ts
+++ b/src/app/detail/detail.component.ts
@@ -1,6 +1,6 @@
 import {Component, OnInit} from '@angular/core';
 import {collectErrors, NaturalAbstractDetail} from '@ecodev/natural';
-import {ItemService} from '../../../projects/natural/src/lib/testing/item.service';
+import {Item, ItemInput, ItemService} from '../../../projects/natural/src/lib/testing/item.service';
 import {NaturalFixedButtonDetailComponent} from '../../../projects/natural/src/lib/modules/fixed-button-detail/fixed-button-detail.component';
 import {CommonModule} from '@angular/common';
 import {MatInputModule} from '@angular/material/input';
@@ -39,5 +39,19 @@ export class DetailComponent extends NaturalAbstractDetail<ItemService> implemen
 
     public constructor(service: ItemService) {
         super('detail', service);
+
+        if (this.isUpdatePage()) {
+            this.doSomethingWithFetchedModel(this.data.model);
+        } else {
+            this.doSomethingWithDefaultValues(this.data.model);
+        }
+    }
+
+    private doSomethingWithFetchedModel(model: Item): string {
+        return model.id;
+    }
+
+    private doSomethingWithDefaultValues(model: ItemInput): boolean {
+        return 'id' in model;
     }
 }

--- a/src/app/relations/relations.component.html
+++ b/src/app/relations/relations.component.html
@@ -3,7 +3,7 @@
     >Use ItemService.watchAll() that always returns 5 elements. Seems to be buggy but it's normal.</div
 >
 
-<div [formGroup]="form" fxLayout="row" fxLayoutGap="50px">
+<div [formGroup]="form" fxLayout="row" fxLayoutGap="50px" *ngIf="isUpdatePage()">
     <div>
         <div class="mat-headline-6">Hierarchic selector</div>
 

--- a/src/app/relations/relations.component.ts
+++ b/src/app/relations/relations.component.ts
@@ -6,13 +6,14 @@ import {NoResultService} from '../../../projects/natural/src/lib/testing/no-resu
 import {NaturalRelationsComponent} from '../../../projects/natural/src/lib/modules/relations/relations.component';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {FlexModule} from '@ngbracket/ngx-layout/flex';
+import {CommonModule} from '@angular/common';
 
 @Component({
     selector: 'app-relations',
     templateUrl: './relations.component.html',
     styleUrls: ['./relations.component.scss'],
     standalone: true,
-    imports: [FlexModule, FormsModule, ReactiveFormsModule, NaturalRelationsComponent],
+    imports: [FlexModule, FormsModule, ReactiveFormsModule, NaturalRelationsComponent, CommonModule],
 })
 export class RelationsComponent extends NaturalAbstractDetail<ItemService> implements OnInit {
     public hierarchicConfig: NaturalHierarchicConfiguration[] = [

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -1,12 +1,11 @@
 import {CommonModule} from '@angular/common';
-import {Component, OnInit, Type} from '@angular/core';
+import {Component, OnInit} from '@angular/core';
 import {MatButtonModule} from '@angular/material/button';
 import {ActivatedRoute, Router} from '@angular/router';
 import {
     DropdownFacet,
     Filter,
     fromUrl,
-    NaturalAbstractModelService,
     NaturalSearchFacets,
     NaturalSearchSelections,
     toGraphQLDoctrineFilter,
@@ -131,23 +130,10 @@ export class SearchComponent implements OnInit {
             component: TypeHierarchicSelectorComponent,
             configuration: {
                 key: 'any',
-                service: this.errorService as unknown as NaturalAbstractModelService<
-                    any,
-                    any,
-                    any,
-                    any,
-                    any,
-                    any,
-                    any,
-                    any,
-                    any,
-                    any
-                >,
+                service: this.errorService,
                 config: [
                     {
-                        service: ErrorService as unknown as Type<
-                            NaturalAbstractModelService<any, any, any, any, any, any, any, any, any, any>
-                        >,
+                        service: ErrorService,
                         parentsRelationNames: ['parent'],
                         childrenRelationNames: ['parent'],
                         selectableAtKey: 'any',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
         "declaration": false,
         "downlevelIteration": true,
         "experimentalDecorators": true,
-        "module": "es2020",
+        "module": "ES2022",
         "moduleResolution": "node",
         "importHelpers": true,
         "target": "ES2022",
@@ -16,7 +16,7 @@
         "forceConsistentCasingInFileNames": true,
         "noFallthroughCasesInSwitch": true,
         "typeRoots": ["node_modules/@types"],
-        "lib": ["es2018", "dom"],
+        "lib": ["ES2022", "dom"],
         "paths": {
             "@ecodev/natural": ["projects/natural/src/public-api"],
             "@ecodev/natural-editor": ["projects/natural-editor/src/public-api"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -8259,6 +8259,11 @@ type-fest@^0.21.3:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
+type-fest@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.2.0.tgz#e259430307710e77721ecf6f545840acad72195f"
+  integrity sha512-5zknd7Dss75pMSED270A1RQS3KloqRJA9XbXLe0eCxyw7xXFb3rd+9B0UQ/0E+LQT6lnrLviEolYORlRWamn4w==
+
 type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"


### PR DESCRIPTION
`NaturalAbstractDetail.data` is implicitly typed with the result of `service.resolve()`. If needed that type can be widened by specifying a type for extra properties in the generic, like so:

```ts
class MyComponent extends NaturalAbstractDetail<MyService, {myProp: string}> {
}
```

`getConsolidatedForClient()` was dropped entirely without a replacement.
 It should never be used in our projects (and it was not).

`getDefaultForClient()` was renamed into `getFormExtraFieldDefaultValues()` to better reflect its usage. It should never be called in projects, only within Natural itself. Projects were updated to instead call `getDefaultForServer()`.

The overall behavior of both `NaturalAbstractModelService` and `NaturalAbstractDetail` is intact.